### PR TITLE
chore(fossa): add .fossa.yml configuration

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,34 @@
+version: 3
+
+project:
+  url: https://github.com/Liam-Deacon/CLEED
+
+# Keep FOSSA focused on maintained source. This repo currently contains many
+# generated artifacts and vendored trees which otherwise produce noisy results.
+paths:
+  exclude:
+    - ./.git
+    - ./build
+    - ./CMakeFiles
+    - ./doc/_build
+    - ./src/contrib
+    - ./src/**/CMakeFiles
+
+vendoredDependencies:
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - ".git/**"
+      - "build/**"
+      - "CMakeFiles/**"
+      - "doc/_build/**"
+      - "src/contrib/**"
+      - "src/**/CMakeFiles/**"
+      - "**/*.exe"
+      - "**/*.o"
+      - "**/*.a"
+      - "**/*.so"
+      - "**/*.dylib"
+      - "**/*.dll"
+      - "**/*.class"
+


### PR DESCRIPTION
Closes #16.

## What
- Adds `.fossa.yml` to configure FOSSA scanning.
- Excludes generated artifacts and vendored trees (e.g. `CMakeFiles/`, `doc/_build/`, `src/contrib/`) so results are stable and actionable.

## Notes
This configuration is intentionally minimal; we can tighten and expand it as we clean repository hygiene and remove non-redistributable code.

## Summary by Sourcery

Add initial FOSSA configuration to enable repository license scanning while excluding generated and vendored artifacts from analysis.

Build:
- Introduce .fossa.yml configuration to define project metadata and path exclusions for FOSSA scans.

Chores:
- Configure vendored dependency scanning rules to ignore binaries and build outputs for cleaner FOSSA results.