### PR TITLE
chore(codacy): add .codacy.yml excludes

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,24 @@
+exclude_paths:
+  # Generated/build artifacts (some are currently committed historically)
+  - "build/**"
+  - "CMakeFiles/**"
+  - "src/**/CMakeFiles/**"
+  - "doc/_build/**"
+
+  # Vendored third-party code
+  - "src/contrib/**"
+
+  # IDE/user configuration files
+  - "**/*.pro.user"
+  - ".externalToolBuilders/**"
+  - ".cproject"
+  - ".project"
+
+  # Binaries and object files (should not be analysed)
+  - "**/*.exe"
+  - "**/*.o"
+  - "**/*.a"
+  - "**/*.so"
+  - "**/*.dylib"
+  - "**/*.dll"
+


### PR DESCRIPTION
Closes #17.

## What
- Adds `.codacy.yml` with explicit `exclude_paths`.
- Prevents Codacy from analysing generated artifacts, IDE state, and vendored third-party trees.

## Why
Keeps Codacy checks stable and focused on code we actually maintain.

## Summary by Sourcery

Build:
- Add Codacy configuration file (.codacy.yml) specifying exclude paths for build artifacts, IDE metadata, binaries, and vendored dependencies.