### PR TITLE
chore(ci): add release packaging + GHCR publish workflows

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,6 +4,7 @@ exclude_paths:
   - "CMakeFiles/**"
   - "src/**/CMakeFiles/**"
   - "doc/_build/**"
+  - "Dockerfile"
 
   # Tests (still checked locally via pre-commit/cppcheck)
   - "tests/**"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -5,6 +5,7 @@ exclude_paths:
   - "src/**/CMakeFiles/**"
   - "doc/_build/**"
   - "Dockerfile"
+  - ".github/workflows/**"
 
   # Tests (still checked locally via pre-commit/cppcheck)
   - "tests/**"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+build/
+doc/_build/
+docs/_build/
+.git/
+.github/
+**/.DS_Store
+**/__pycache__/
+

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,4 +49,3 @@ template: |
 
   ## Contributors
   $CONTRIBUTORS
-

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,52 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+no-changes-template: "- No changes"
+sort-direction: ascending
+
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking"
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+      - "docs"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "ci"
+      - "build"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+      - "fix"
+  default: patch
+
+template: |
+  ## Summary
+  $CHANGES
+
+  ## Contributors
+  $CONTRIBUTORS
+

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -14,13 +14,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@v6.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        uses: docker/login-action@v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -28,14 +28,14 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
+        uses: docker/metadata-action@v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/cleed
           tags: |
             type=ref,event=tag
 
       - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           push: true

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Log in to GHCR
         uses: docker/login-action@v3.6.0

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -14,13 +14,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -28,17 +28,16 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ghcr.io/${{ github.repository_owner }}/cleed
           tags: |
             type=ref,event=tag
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,44 @@
+name: Docker (GHCR)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/cleed
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -3,8 +3,6 @@ name: Release Drafter
 on:
   push:
     branches: ["master"]
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
   workflow_dispatch:
 
 permissions:
@@ -20,4 +18,3 @@ jobs:
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6.1.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Source compliance guard
         run: python tools/check_nr_free.py
@@ -109,7 +109,7 @@ jobs:
           cpack -C $env:BUILD_TYPE -G NSIS
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: packages-${{ matrix.os }}
           path: |
@@ -126,13 +126,12 @@ jobs:
     needs: build-packages
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: dist
 
       - name: Publish
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           files: dist/**/*
           generate_release_notes: true
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@v6.0.1
 
       - name: Source compliance guard
         run: python tools/check_nr_free.py
@@ -109,7 +109,7 @@ jobs:
           cpack -C $env:BUILD_TYPE -G NSIS
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: packages-${{ matrix.os }}
           path: |
@@ -126,12 +126,12 @@ jobs:
     needs: build-packages
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@v7.0.0
         with:
           path: dist
 
       - name: Publish
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@v2.5.0
         with:
           files: dist/**/*
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   BUILD_TYPE: Release
+  VCPKG_VERSION: 2025.12.12
 
 jobs:
   build-packages:
@@ -19,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
       - uses: actions/checkout@v6.0.1
@@ -39,13 +40,27 @@ jobs:
         run: |
           brew install libtiff
 
+      - name: Cache vcpkg (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v5.0.1
+        with:
+          path: ${{ github.workspace }}/vcpkg
+          key: vcpkg-${{ runner.os }}-x64-windows-${{ env.VCPKG_VERSION }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-x64-windows-
+
       - name: Install build dependencies (Windows via vcpkg)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          git clone https://github.com/microsoft/vcpkg "$env:GITHUB_WORKSPACE/vcpkg"
-          & "$env:GITHUB_WORKSPACE/vcpkg/bootstrap-vcpkg.bat"
-          & "$env:GITHUB_WORKSPACE/vcpkg/vcpkg.exe" install tiff:x64-windows
+          $vcpkgRoot = "$env:GITHUB_WORKSPACE/vcpkg"
+          if (-not (Test-Path $vcpkgRoot)) {
+            git clone --branch "$env:VCPKG_VERSION" --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
+          }
+          if (-not (Test-Path "$vcpkgRoot/vcpkg.exe")) {
+            & "$vcpkgRoot/bootstrap-vcpkg.bat"
+          }
+          & "$vcpkgRoot/vcpkg.exe" install tiff:x64-windows
 
       - name: Install NSIS (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-packages:
+    name: Package (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Source compliance guard
+        run: python tools/check_nr_free.py
+
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            libtiff-dev rpm
+
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install libtiff
+
+      - name: Install build dependencies (Windows via vcpkg)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          git clone https://github.com/microsoft/vcpkg "$env:GITHUB_WORKSPACE/vcpkg"
+          & "$env:GITHUB_WORKSPACE/vcpkg/bootstrap-vcpkg.bat"
+          & "$env:GITHUB_WORKSPACE/vcpkg/vcpkg.exe" install tiff:x64-windows
+
+      - name: Install NSIS (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install nsis -y
+          Get-Command makensis
+
+      - name: Configure CMake (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: >
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DWITH_QT=OFF
+          -DWITH_OPENCL=OFF
+          -DWITH_PHASESHIFTS=OFF
+          -DINSTALL_DOC=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        run: >
+          cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build
+          -A x64
+          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=x64-windows
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DWITH_QT=OFF
+          -DWITH_OPENCL=OFF
+          -DWITH_PHASESHIFTS=OFF
+          -DINSTALL_DOC=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
+
+      - name: Package (Linux)
+        if: runner.os == 'Linux'
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          cpack -C "${BUILD_TYPE}" -G TGZ
+          cpack -C "${BUILD_TYPE}" -G DEB || true
+          cpack -C "${BUILD_TYPE}" -G RPM || true
+
+      - name: Package (macOS)
+        if: runner.os == 'macOS'
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          cpack -C "${BUILD_TYPE}" -G TGZ
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        working-directory: ${{ github.workspace }}/build
+        shell: pwsh
+        run: |
+          cpack -C $env:BUILD_TYPE -G ZIP
+          cpack -C $env:BUILD_TYPE -G NSIS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.os }}
+          path: |
+            build/*.zip
+            build/*.tar.gz
+            build/*.tgz
+            build/*.deb
+            build/*.rpm
+            build/*.exe
+
+  github-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-packages
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*
+          generate_release_notes: true
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,8 +130,39 @@ jobs:
         with:
           path: dist
 
+      - name: Determine release flags (PEP 440)
+        id: flags
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+
+          # PEP 440 prereleases: X.Y.ZaN, X.Y.ZbN, X.Y.ZrcN; also dev releases: X.Y.Z.devN
+          prerelease=false
+          draft=false
+
+          if [[ "${version}" =~ (^|[0-9])a[0-9]+$ ]] || [[ "${version}" =~ (^|[0-9])b[0-9]+$ ]] || [[ "${version}" =~ rc[0-9]+$ ]] || [[ "${version}" =~ \\.dev[0-9]+$ ]]; then
+            prerelease=true
+          fi
+
+          # Keep dev releases as drafts by default (useful for CI-produced artifacts without announcing).
+          if [[ "${version}" =~ \\.dev[0-9]+$ ]]; then
+            draft=true
+          fi
+
+          {
+            echo "version=${version}"
+            echo "prerelease=${prerelease}"
+            echo "draft=${draft}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Publish
         uses: softprops/action-gh-release@v2.5.0
         with:
+          name: ${{ steps.flags.outputs.version }}
+          prerelease: ${{ steps.flags.outputs.prerelease }}
+          draft: ${{ steps.flags.outputs.draft }}
           files: dist/**/*
           generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=build /opt/cleed/ /usr/local/
 
+RUN useradd --system --uid 1000 --create-home --home-dir /home/cleed cleed \
+    && chown -R cleed:cleed /usr/local
+
+USER cleed
+WORKDIR /home/cleed
+
 ENTRYPOINT ["cleed_nsym"]
 CMD ["-h"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:22.04 AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    ninja-build \
+    libtiff-dev \
+    libpng-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cmake -S . -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_QT=OFF \
+    -DWITH_OPENCL=OFF \
+    -DWITH_PHASESHIFTS=OFF \
+    -DINSTALL_DOC=OFF \
+    -DBUILD_TESTING=OFF
+
+RUN cmake --build build --parallel
+RUN cmake --install build --prefix /opt/cleed
+
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtiff6 \
+    libpng16-16 \
+    zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /opt/cleed/ /usr/local/
+
+ENTRYPOINT ["cleed_nsym"]
+CMD ["-h"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN cmake -S . -B build -G Ninja \
     -DINSTALL_DOC=OFF \
     -DBUILD_TESTING=OFF
 
-RUN cmake --build build --parallel
-RUN cmake --install build --prefix /opt/cleed
+RUN cmake --build build --parallel && \
+    cmake --install build --prefix /opt/cleed
 
 FROM ubuntu:22.04
 


### PR DESCRIPTION
## Problem
- Need CI-backed release automation: cross-platform build+test, attach packages to GitHub Releases, and publish a Docker image.

## Solution
- Add a tag-triggered **Release** workflow that:
  - builds + runs tests on `ubuntu-latest`, `macos-latest`, `windows-latest`
  - runs CPack to generate platform-appropriate artifacts
  - uploads artifacts to the GitHub Release
- Add a tag-triggered **Docker (GHCR)** workflow that builds and pushes `ghcr.io/<owner>/cleed:<tag>`.

## Artifacts (intended)

| OS | Packaging step | Typical outputs |
|---|---|---|
| Linux | `cpack -G TGZ/DEB/RPM` | `*.tar.gz`, `*.deb`, `*.rpm` |
| macOS | `cpack -G TGZ` | `*.tar.gz` |
| Windows | `cpack -G ZIP/NSIS` | `*.zip`, `*.exe` |

```mermaid
flowchart TB
  Tag[push tag v*] --> Build[build+test matrix]
  Build --> CPack[CPack packaging]
  CPack --> Release[GitHub Release assets]
  Tag --> Docker[Docker build+push]
  Docker --> GHCR[ghcr.io image]
```

## Testing
- Local (macOS): `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_QT=OFF -DWITH_OPENCL=OFF -DWITH_PHASESHIFTS=OFF -DINSTALL_DOC=OFF -DBUILD_TESTING=ON && cmake --build build --parallel && ctest --test-dir build --output-on-failure`

## Notes / limitations
- Release + Docker workflows run on tags (`v*`) and via `workflow_dispatch` (not on PRs).
- Homebrew tap automation is intentionally left as a follow-up (requires a dedicated tap repo and credentials).

## References
- GitHub Releases via Actions: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
- softprops/action-gh-release: https://github.com/softprops/action-gh-release
- GitHub Container Registry (GHCR): https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
- docker/build-push-action: https://github.com/docker/build-push-action

Refs: #11

## Summary by Sourcery

Add automated release packaging and Docker image publishing workflows triggered by version tags.

Build:
- Introduce a cross-platform GitHub Actions release workflow that builds, tests, packages with CPack, and uploads artifacts to GitHub Releases.
- Add a GitHub Actions workflow to build and publish Docker images to GitHub Container Registry on tagged releases.
- Add a multi-stage Dockerfile and .dockerignore to support building and running the project in a container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image build & publish on tag releases.
  * Added automated release drafting and publishing workflows and a release-notes template.
  * Added multi-platform release packaging for Windows, macOS, and Linux.
  * Added optimized multi-stage container build for the runtime.
  * Expanded CI/CD analysis exclusions and added container build ignore rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->