### PR TITLE
chore(ci): fix release action versions

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -14,7 +14,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -35,7 +35,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
 
       - name: Source compliance guard
         run: python tools/check_nr_free.py
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache vcpkg (Windows)
         if: runner.os == 'Windows'
-        uses: actions/cache@v5.0.1
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/vcpkg
           key: vcpkg-${{ runner.os }}-x64-windows-${{ env.VCPKG_VERSION }}
@@ -124,7 +124,7 @@ jobs:
           cpack -C $env:BUILD_TYPE -G NSIS
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.os }}
           path: |
@@ -141,7 +141,7 @@ jobs:
     needs: build-packages
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v4
         with:
           path: dist
 
@@ -179,5 +179,8 @@ jobs:
           name: ${{ steps.flags.outputs.version }}
           prerelease: ${{ steps.flags.outputs.prerelease }}
           draft: ${{ steps.flags.outputs.draft }}
+          body: |
+            ## Docker image
+            `ghcr.io/${{ github.repository_owner }}/cleed:${{ steps.flags.outputs.version }}`
           files: dist/**/*
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,6 +181,6 @@ jobs:
           draft: ${{ steps.flags.outputs.draft }}
           body: |
             ## Docker image
-            `ghcr.io/${{ github.repository_owner }}/cleed:${{ steps.flags.outputs.version }}`
+            `ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.flags.outputs.version }}`
           files: dist/**/*
           generate_release_notes: true


### PR DESCRIPTION
## Problem
Release/CI automation needs to be reliable and publish artifacts + Docker images for tagged releases (issue #11). The current workflow references non-existent action versions and doesn’t surface the GHCR image in release notes.

## Solution
- Pin Actions to valid major tags (checkout/cache/artifacts) in release workflow.
- Keep Docker publish workflow aligned with a supported build/push action version.
- Add a short GHCR image note to GitHub release bodies.

## Testing
- Not run (workflow-only change).

## Follow-ups
- [ ] Confirm whether macOS should produce pkg/dmg artifacts or tarball is sufficient.
- [ ] Confirm preferred release notes style (release-drafter vs auto-generated).

## Summary by Sourcery

Align CI release and Docker publish workflows with supported GitHub and Docker action versions and surface the published GHCR image in GitHub release bodies.

Enhancements:
- Include a GHCR Docker image reference in the generated GitHub release body.

CI:
- Pin checkout, cache, and artifact-related GitHub Actions in the release workflow to supported major versions.
- Pin the Docker build-push action in the docker-publish workflow to a supported major version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Release notes now include Docker image information for published builds, showing image path and version tag.
* **Chores**
  * CI/CD workflow configuration updated (internal build workflow adjustments; no user-facing behavior changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->