### PR TITLE
feat(phaseshifts): add helper CLI

### DIFF
--- a/doc/aux_programs/phsh.rst
+++ b/doc/aux_programs/phsh.rst
@@ -102,6 +102,39 @@ after execution. When operating in this mode, the following assumptions are made
   :envvar:`CLEED_PHASE` is, however, found then the program will place the 
   generated files in this directory unless a specific `-S <subdir>` is provided.
   
+cleed_phaseshifts.py helper
+---------------------------
+
+CLEED ships a small helper script, :file:`cleed_phaseshifts.py`, that wraps the
+``phsh.py`` CLI and records a manifest for reproducible phase shift generation.
+
+Usage::
+
+  cleed_phaseshifts.py -b Ni111_2x2O.bul -i Ni111_2x2O.inp -o ./phase
+
+This will:
+
+- Generate ``*.phs`` files using ``phsh.py`` with ``-g`` (generate only).
+- Write outputs to the provided ``--output-dir`` (or ``$CLEED_PHASE``).
+- Emit ``phaseshifts-manifest.json`` containing input hashes and command info.
+
+If ``phsh.py`` is not on your ``PATH``, pass ``--phsh /path/to/phsh.py``.
+
+Example workflow
+^^^^^^^^^^^^^^^^
+
+1. Generate phase shifts::
+
+     cleed_phaseshifts.py -b Ni111_2x2O.bul -i Ni111_2x2O.inp -o ./phase
+
+2. Point CLEED at the generated phase shifts::
+
+     export CLEED_PHASE=\"$(pwd)/phase\"
+
+3. Run CLEED with the matching input set::
+
+     cleed_nsym -c Ni111_2x2O.ctr -i Ni111_2x2O.inp -b Ni111_2x2O.bul
+
 .. _phsh_notes:
   
 Notes

--- a/src/scripts/cleed_phaseshifts.py
+++ b/src/scripts/cleed_phaseshifts.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate CLEED phase shift files via the phaseshifts package."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def sha256sum(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def phaseshifts_version() -> str:
+    try:
+        import phaseshifts  # type: ignore
+
+        return getattr(phaseshifts, "__version__", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def resolve_phsh(binary: str) -> str:
+    resolved = shutil.which(binary)
+    return resolved or binary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate CLEED phase shift files using phaseshifts.",
+    )
+    parser.add_argument("-b", "--bulk", required=True, help="Bulk .bul input file")
+    parser.add_argument("-i", "--slab", required=True, help="Slab .inp input file")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=os.environ.get("CLEED_PHASE", ""),
+        help="Output directory for .phs files (defaults to CLEED_PHASE)",
+    )
+    parser.add_argument(
+        "-l",
+        "--lmax",
+        type=int,
+        default=None,
+        help="Maximum angular momentum quantum number",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        default="CLEED",
+        help="Phase shift output format (default: CLEED)",
+    )
+    parser.add_argument(
+        "-t",
+        "--tmpdir",
+        default=None,
+        help="Temporary directory for intermediate files",
+    )
+    parser.add_argument(
+        "--phsh",
+        default="phsh.py",
+        help="Path to phaseshifts phsh.py executable",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Path to write a JSON manifest (defaults to <output-dir>/phaseshifts-manifest.json)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    bulk = Path(args.bulk)
+    slab = Path(args.slab)
+    if not bulk.exists():
+        parser.error(f"Bulk file not found: {bulk}")
+    if not slab.exists():
+        parser.error(f"Slab file not found: {slab}")
+
+    output_dir = Path(args.output_dir) if args.output_dir else None
+    if output_dir is None:
+        parser.error("Output directory is required (set CLEED_PHASE or --output-dir)")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = (
+        Path(args.manifest)
+        if args.manifest
+        else output_dir / "phaseshifts-manifest.json"
+    )
+
+    phsh = resolve_phsh(args.phsh)
+    if shutil.which(phsh) is None and not Path(phsh).exists():
+        parser.error(
+            f\"phsh.py not found (searched for '{args.phsh}'); install phaseshifts or pass --phsh\"
+        )
+    cmd = [phsh, "-g", "-b", str(bulk), "-i", str(slab), "-f", args.format]
+    if args.lmax is not None:
+        cmd.extend(["-l", str(args.lmax)])
+    if args.tmpdir:
+        cmd.extend(["-t", args.tmpdir])
+
+    env = os.environ.copy()
+    env["CLEED_PHASE"] = str(output_dir)
+
+    try:
+        subprocess.run(cmd, check=True, env=env)
+    except FileNotFoundError as exc:
+        print(f\"Failed to execute {phsh}: {exc}\", file=sys.stderr)
+        return 127
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode
+
+    phs_files = sorted(p.name for p in output_dir.glob("*.phs"))
+    manifest = {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "phaseshifts_version": phaseshifts_version(),
+        "bulk": {
+            "path": str(bulk.resolve()),
+            "sha256": sha256sum(bulk),
+        },
+        "slab": {
+            "path": str(slab.resolve()),
+            "sha256": sha256sum(slab),
+        },
+        "command": cmd,
+        "cleed_phase": str(output_dir.resolve()),
+        "outputs": phs_files,
+    }
+
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(f"Wrote phase shifts to {output_dir}")
+    print(f"Manifest: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scripts/cleed_phaseshifts.py
+++ b/src/scripts/cleed_phaseshifts.py
@@ -105,7 +105,7 @@ def main() -> int:
     phsh = resolve_phsh(args.phsh)
     if shutil.which(phsh) is None and not Path(phsh).exists():
         parser.error(
-            f\"phsh.py not found (searched for '{args.phsh}'); install phaseshifts or pass --phsh\"
+            f"phsh.py not found (searched for '{args.phsh}'); install phaseshifts or pass --phsh"
         )
     cmd = [phsh, "-g", "-b", str(bulk), "-i", str(slab), "-f", args.format]
     if args.lmax is not None:
@@ -119,7 +119,7 @@ def main() -> int:
     try:
         subprocess.run(cmd, check=True, env=env)
     except FileNotFoundError as exc:
-        print(f\"Failed to execute {phsh}: {exc}\", file=sys.stderr)
+        print(f"Failed to execute {phsh}: {exc}", file=sys.stderr)
         return 127
     except subprocess.CalledProcessError as exc:
         return exc.returncode


### PR DESCRIPTION
## Problem
Issue #44 asks for a reproducible phaseshifts integration so users can generate phase shift files and run CLEED without manual file munging.

## Solution
- Add `src/scripts/cleed_phaseshifts.py`, a wrapper around `phsh.py` that writes output to `CLEED_PHASE` (or `--output-dir`) and records a JSON manifest with hashes + versions.
- Document the helper and a full workflow in `doc/aux_programs/phsh.rst`.

## Testing
- Not run (script and documentation only).

## Follow-ups
- [ ] Decide whether to wire caching or a session directory layout into the helper.
- [ ] Clarify if we should add a Python API wrapper once `cleed` ships as a package.

## Summary by Sourcery

Add a command-line helper to generate CLEED phase shift files using the phaseshifts package and record outputs in a JSON manifest.

New Features:
- Introduce the cleed_phaseshifts.py CLI script to wrap phaseshifts/phsh.py and write phase shift files into a chosen output directory with a JSON manifest of inputs and outputs.

Documentation:
- Document the new phaseshifts helper script and describe an end-to-end workflow for generating CLEED phase shift files.