### PR TITLE
feat(python): add cleed wrapper package

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Contents:
    introduction
    background
    environment
+   python_package
    file_formats
    LEED_programs
    aux_programs

--- a/doc/python_package.rst
+++ b/doc/python_package.rst
@@ -1,0 +1,44 @@
+.. _python_package:
+
+************************
+Python package (cleed)
+************************
+
+Status
+======
+
+The Python package is an initial wrapper around the CLEED executables. It does
+not yet bundle native binaries; instead, it provides a CLI that invokes
+executables available on the system ``PATH``. Wheel build and bundling are
+planned as follow-ups.
+
+Install
+=======
+
+From source (editable):
+
+.. code-block:: console
+
+   python3 -m pip install -e .
+
+CLI usage
+=========
+
+List available tools:
+
+.. code-block:: console
+
+   cleed --list-tools
+
+Invoke a tool, passing args through after ``--``:
+
+.. code-block:: console
+
+   cleed cleed_nsym -- -c Ni111_2x2O.ctr -i Ni111_2x2O.inp -b Ni111_2x2O.bul
+
+Build plan
+==========
+
+Future work (see `issue #37 <https://github.com/Liam-Deacon/CLEED/issues/37>`_)
+will replace the PATH-based wrapper with packaged binaries and wheels built
+via CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cleed"
+version = "0.0.0"
+description = "Computational Low Energy Electron Diffraction (CLEED) tooling"
+readme = "Readme.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE.txt" }
+authors = [
+  { name = "Liam Deacon", email = "liam.deacon@diamond.ac.uk" }
+]
+keywords = ["LEED", "diffraction", "surface"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+phaseshifts = ["phaseshifts"]
+
+[project.scripts]
+cleed = "cleed.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+
+[tool.setuptools.packages.find]
+where = ["python"]

--- a/python/cleed/__init__.py
+++ b/python/cleed/__init__.py
@@ -1,0 +1,5 @@
+"""Python entry points for the CLEED toolchain."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0"

--- a/python/cleed/cli.py
+++ b/python/cleed/cli.py
@@ -1,0 +1,98 @@
+"""CLI wrapper for invoking CLEED executables from a Python install."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from typing import List
+
+from . import __version__
+
+TOOLS = {
+    "cleed_nsym": "Run the non-symmetry CLEED solver",
+    "cleed_sym": "Run the symmetry CLEED solver",
+    "csearch": "Run the structure search driver",
+    "crfac": "Compute R-factors",
+}
+
+
+def resolve_tool(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def run_tool(binary: str, args: List[str]) -> int:
+    try:
+        result = subprocess.run([binary] + args, check=False)
+    except FileNotFoundError:
+        return 127
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run CLEED executables from a Python install.",
+    )
+    parser.add_argument(
+        "--list-tools",
+        action="store_true",
+        help="List supported tools and exit",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the cleed Python package version",
+    )
+    parser.add_argument(
+        "tool",
+        nargs="?",
+        help="Executable to run (e.g. cleed_nsym, csearch)",
+    )
+    parser.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="Arguments passed through to the underlying executable",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        print(__version__)
+        return 0
+
+    if args.list_tools:
+        for name, description in TOOLS.items():
+            print(f"{name}\t{description}")
+        return 0
+
+    if not args.tool:
+        parser.print_help()
+        return 2
+
+    if args.tool not in TOOLS:
+        print(f"Unknown tool: {args.tool}", file=sys.stderr)
+        print("Use --list-tools to see available options.", file=sys.stderr)
+        return 2
+
+    binary = resolve_tool(args.tool)
+    if not binary:
+        print(
+            f"Executable not found on PATH: {args.tool}",
+            file=sys.stderr,
+        )
+        return 127
+
+    tool_args = args.args
+    if tool_args and tool_args[0] == "--":
+        tool_args = tool_args[1:]
+
+    return run_tool(binary, tool_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem
Issue #37 asks for a `cleed` Python package that enables CLI usage and a path toward bundled binaries and wheels.

## Solution
- Add `pyproject.toml` with minimal package metadata.
- Create a lightweight `cleed` Python package that provides a CLI wrapper for existing CLEED executables on `PATH`.
- Document the current wrapper behavior and future wheel packaging plan in Sphinx docs.

## Testing
- Not run (packaging and docs only).

## Follow-ups
- [ ] Decide on a build backend (scikit-build-core vs setuptools) for native binaries.
- [ ] Determine how to bundle executables and data into wheels.
- [ ] Add CI wheel builds (cibuildwheel) and smoke tests.

## Summary by Sourcery

Introduce a minimal Python `cleed` package providing a CLI entry point that wraps existing CLEED executables discovered on PATH.

New Features:
- Add a `cleed` Python package exposing a `cleed` console script to run CLEED tools such as `cleed_nsym`, `cleed_sym`, `csearch`, and `crfac` from a Python installation.

Build:
- Add a `pyproject.toml` configured with setuptools to build and distribute the `cleed` package, including an optional `phaseshifts` extra dependency.

Documentation:
- Add initial Sphinx documentation page describing the Python package and its CLI wrapper behavior.