### PR TITLE
docs(guide): expand onboarding materials

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.bibtex',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -94,6 +95,9 @@ exclude_patterns = ['_build']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
+
+# Bibliography sources for sphinxcontrib-bibtex.
+bibtex_bibfiles = ['references.bib']
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,12 +16,15 @@ Contents:
    :glob:
    
    introduction
+   start_here
    background
    environment
    file_formats
    LEED_programs
    aux_programs
    downloads
+   troubleshooting
+   references
    changelog
    FAQ
    authors

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,0 +1,18 @@
+@article{pendry1980,
+  author = {Pendry, J. B.},
+  title = {Reliability factors for LEED calculations},
+  journal = {Journal of Physics C: Solid State Physics},
+  volume = {13},
+  number = {5},
+  pages = {937-944},
+  year = {1980},
+  doi = {10.1088/0022-3719/13/5/012}
+}
+
+@book{vanhove1984,
+  author = {Van Hove, M. A. and Tong, S. Y.},
+  title = {Surface Crystallography by LEED},
+  publisher = {Springer},
+  year = {1984},
+  isbn = {978-3-540-13380-0}
+}

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,0 +1,12 @@
+.. _references:
+
+**********
+References
+**********
+
+This bibliography collects primary sources referenced throughout the CLEED
+manual and tutorials.
+
+.. bibliography:: references.bib
+   :all:
+

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=7.2,<9
 sphinx-rtd-theme>=2.0,<4
-
+sphinxcontrib-bibtex>=2.5,<3

--- a/doc/start_here.rst
+++ b/doc/start_here.rst
@@ -1,0 +1,56 @@
+.. _start_here:
+
+**************************
+Start here: LEED-IV in CLEED
+**************************
+
+This guide is a short, practical introduction for new LEED-IV users. It
+summarizes the modeling loop and gives an end-to-end example you can run from
+``examples/``.
+
+What is LEED-IV?
+================
+
+Low Energy Electron Diffraction (LEED) compares experimental intensity-versus-
+energy curves against theoretical simulations. The goal is to adjust the
+surface structure until the theoretical I(V) curves match experiment within a
+reliability metric. For background, see :cite:p:`vanhove1984` and the Pendry
+R-factor reference :cite:p:`pendry1980`.
+
+Program loop
+============
+
+The core CLEED loop is:
+
+1. **csearch**: selects candidate geometries.
+2. **cleed_***: computes theoretical I(V) curves.
+3. **crfac**: evaluates an R-factor for the current geometry.
+
+This is repeated until convergence.
+
+Inputs you need
+===============
+
+- ``*.bul``: bulk geometry and fixed parameters.
+- ``*.inp``: surface geometry and search parameters.
+- ``*.ctr``: experimental vs theoretical curve mapping.
+- ``*.phs``: phase shift files generated per element.
+
+See :ref:`file_formats` for details.
+
+End-to-end example (fixed geometry)
+===================================
+
+This example runs a single theoretical calculation and an R-factor evaluation
+using the shipped Ni(111) + 2x2 O example:
+
+.. code-block:: console
+
+   cd examples/models/nio
+   export CLEED_PHASE="$(pwd)/phase"
+   phsh.py -g -b Ni111_2x2O.bul -i Ni111_2x2O.inp -f CLEED
+   cleed_nsym -c Ni111_2x2O.ctr -i Ni111_2x2O.inp -b Ni111_2x2O.bul
+   crfac -c Ni111_2x2O.ctr -t Ni111_2x2O.res
+
+If you are running a full structure search, ``csearch`` can orchestrate the
+loop when provided matching ``.inp/.bul/.ctr`` files.

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -1,0 +1,41 @@
+.. _troubleshooting:
+
+****************
+Troubleshooting
+****************
+
+Common issues and quick checks when running CLEED.
+
+Missing phase shift files
+=========================
+
+Symptoms: errors about missing ``*.phs`` or no phase shift directory.
+
+- Ensure ``CLEED_PHASE`` points to a directory containing element ``.phs`` files.
+- Regenerate phase shifts with ``phsh.py`` and verify output names.
+
+Input file prefix mismatch
+==========================
+
+Symptoms: tools cannot find matching inputs or generate output files with
+unexpected names.
+
+- Use the same prefix for ``.bul``, ``.inp``, and ``.ctr`` files (for example,
+  ``Ni111_2x2O``).
+
+R-factor fails to find theoretical beams
+========================================
+
+Symptoms: ``crfac`` reports missing theoretical indices.
+
+- Verify that your ``.ctr`` mappings match the beam list in the ``.res`` file.
+- Check that the calculated energy range overlaps the experimental data.
+
+Unexpected parameter defaults
+=============================
+
+Symptoms: runs succeed but results look wrong or ignore expected settings.
+
+- Parameters can appear in any order; the last occurrence is used.
+- If a parameter is missing, CLEED may fall back to an internal default.
+


### PR DESCRIPTION
## Problem
Issue #34 calls for improved onboarding docs, troubleshooting, and inline scientific references for LEED-IV users, plus a bibliography system in Sphinx.

## Solution
- Add a start-here guide and troubleshooting page aimed at first-time LEED-IV users.
- Add a references page backed by sphinxcontrib-bibtex and two core citations.
- Wire new docs into the Sphinx index and add bibtex to doc requirements.

## Testing
- Not run (documentation-only changes).

## Follow-ups
- [ ] Decide the scope for Doxygen markup across core modules.
- [ ] Expand bibliography with additional references tied to specific algorithms.
- [ ] Add a full end-to-end tutorial that uses experimental data inputs.

## Summary by Sourcery

Expand and restructure the Sphinx documentation to improve onboarding for LEED-IV users and introduce a citation-backed references system.

New Features:
- Add a start-here guide for first-time LEED-IV users.
- Add a troubleshooting page focused on common LEED-IV setup and usage issues.
- Introduce a references page backed by a BibTeX bibliography containing core LEED-related citations.

Enhancements:
- Enable sphinxcontrib-bibtex in the Sphinx configuration and wire a shared bibliography file into the docs build.
- Update the Sphinx index and documentation structure to include the new onboarding and reference pages.

Build:
- Add sphinxcontrib-bibtex to the documentation build requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Getting Started" guide featuring LEED-IV definitions, program workflow, and practical end-to-end example
  * Added Troubleshooting section addressing common issues with actionable solutions
  * Added References section with curated bibliography
  * Updated documentation navigation and structure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->