### PR TITLE
docs(gui): add Qt6 status page

### DIFF
--- a/doc/gui_status.rst
+++ b/doc/gui_status.rst
@@ -1,0 +1,37 @@
+.. _gui_status:
+
+*********************
+GUI status and Qt6 plan
+*********************
+
+This page summarizes the current GUI stack and the modernization plan for
+issues #9 and #26.
+
+C++ Qt GUIs
+===========
+
+- GUI targets are optional and gated by ``-DWITH_QT=ON``.
+- The build prefers Qt6, then Qt5, and only falls back to Qt4 if needed.
+- Current CMake targets: ``latt-gui`` and ``patt-gui``.
+
+Recommendation
+--------------
+
+Use Qt6 where possible. When Qt is not available, configure with
+``-DWITH_QT=OFF`` to build the headless CLI tools only.
+
+Python GUIs (legacy)
+====================
+
+The legacy Python GUIs under ``src/cleed-gui`` and ``src/mkiv-gui`` still use
+PyQt4 and QtWebKit, both of which are deprecated. These components are not
+currently built or tested in CI.
+
+Next decisions
+--------------
+
+- Choose a primary GUI stack:
+  - C++ Qt6 Widgets, or
+  - Python Qt6 (PySide6 recommended for licensing).
+- Decide whether to migrate the legacy Python GUIs or replace them entirely.
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Contents:
    introduction
    background
    environment
+   gui_status
    file_formats
    LEED_programs
    aux_programs


### PR DESCRIPTION
## Problem
Issues #9 and #26 require a Qt6 modernization plan and clarity on the current GUI stack.

## Solution
- Add a Sphinx page documenting GUI status, Qt6 preference, and the legacy PyQt4 state.
- Wire the page into the main documentation index.

## Testing
- Not run (documentation-only change).

## Follow-ups
- [ ] Decide on the primary GUI stack (C++ Qt6 vs Python PySide6).
- [ ] Plan the actual migration of Qt4/PyQt4 code and remove deprecated dependencies.

## Summary by Sourcery

Document current GUI technology stack and Qt6 migration plans in the Sphinx docs.

Documentation:
- Add a GUI status documentation page describing Qt6 preference and legacy PyQt4 usage.
- Link the new GUI status page into the main Sphinx documentation index.