### PR TITLE
feat(search): add optimizer interface config

### DIFF
--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -48,6 +48,23 @@ Options
   Specifies the search algorithm to be used for the structure
   optimisation. Possible arguments are:
 
+  - :code:`si` / :code:`sx`: simplex (default).
+  - :code:`po`: Powell.
+  - :code:`sa`: simulated annealing.
+  - :code:`ga`: genetic algorithm (not implemented).
+
+:code:`--max-evals <n>`
+
+  Limits objective evaluations (simplex). Overrides the default iteration budget.
+
+:code:`--max-iters <n>`
+
+  Limits iterations (Powell/annealing). Overrides the default iteration budget.
+
+:code:`--seed <n>`
+
+  Sets a deterministic seed for stochastic optimizers (simulated annealing).
+
 :code:`-v <vertex_file>`
                      
   Allows the search to be restarted with the current simplex, provided 
@@ -70,6 +87,15 @@ Environment
 :envvar:`CSEARCH_RFAC`
   Path of the crfac program  used  for the R factor evaluation. This may simply be 'crfac'
   if the parent directory of this program is in the system :envvar:`PATH` variable.
+
+:envvar:`CSEARCH_MAX_EVALS`
+  Optional evaluation budget for simplex searches (same as :code:`--max-evals`).
+
+:envvar:`CSEARCH_MAX_ITERS`
+  Optional iteration budget for Powell/annealing searches (same as :code:`--max-iters`).
+
+:envvar:`CSEARCH_SEED`
+  Optional deterministic seed for simulated annealing (same as :code:`--seed`).
 
 :envvar:`CLEED_PHASE`
   Directory path of the phase shift files used in  the  surface and bulk models. 

--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -65,6 +65,11 @@ Options
 
   Sets a deterministic seed for stochastic optimizers (simulated annealing).
 
+.. note::
+   Seeds are parsed as unsigned 64-bit integers. A value of 0 selects the
+   built-in default used by the deterministic annealing RNG; non-zero seeds
+   reproduce runs across platforms.
+
 :code:`-v <vertex_file>`
                      
   Allows the search to be restarted with the current simplex, provided 
@@ -96,6 +101,9 @@ Environment
 
 :envvar:`CSEARCH_SEED`
   Optional deterministic seed for simulated annealing (same as :code:`--seed`).
+
+  A value of 0 uses the built-in default seed for the deterministic annealing
+  RNG. Non-zero values are parsed as unsigned 64-bit integers.
 
 :envvar:`CLEED_PHASE`
   Directory path of the phase shift files used in  the  surface and bulk models. 

--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -40,6 +40,9 @@ This page defines the environment variables referenced throughout the manual.
 
    Optional deterministic seed for stochastic optimizers (same as ``--seed``).
 
+   Seeds are parsed as unsigned 64-bit integers. A value of 0 uses the built-in
+   default seed for the annealing RNG.
+
 .. envvar:: RF_HELP_FILE
 
    Path to a help file shown when :ref:`crfac` is invoked with ``-h``.

--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -28,6 +28,18 @@ This page defines the environment variables referenced throughout the manual.
    Path to the R-factor executable used by :ref:`csearch` (commonly
    :ref:`crfac`).
 
+.. envvar:: CSEARCH_MAX_EVALS
+
+   Optional evaluation budget for :ref:`csearch` (same as ``--max-evals``).
+
+.. envvar:: CSEARCH_MAX_ITERS
+
+   Optional iteration budget for :ref:`csearch` (same as ``--max-iters``).
+
+.. envvar:: CSEARCH_SEED
+
+   Optional deterministic seed for stochastic optimizers (same as ``--seed``).
+
 .. envvar:: RF_HELP_FILE
 
    Path to a help file shown when :ref:`crfac` is invoked with ``-h``.

--- a/man/csearch.1
+++ b/man/csearch.1
@@ -52,6 +52,22 @@ specifies the search algorithm to be used for the structure optimisation. Possib
 .br
 'si' : Simplex algorithm
 'sx' : Simplex algorithm (alternative)
+.RE
+.IP --max-evals
+.I <n>
+.RS
+limits objective evaluations (simplex). This overrides the default iteration budget.
+.RE
+.IP --max-iters
+.I <n>
+.RS
+limits iterations (Powell/annealing). This overrides the default iteration budget.
+.RE
+.IP --seed
+.I <n>
+.RS
+sets a deterministic seed for stochastic optimizers (simulated annealing).
+.RE
 .IP -v
 .I <vertex_file> 
 .RS
@@ -70,6 +86,12 @@ CSEARCH_LEED: path of the program used for the LEED calculations. This may simpl
 CSEARCH_RFAC: path of the 
 .I crfac
  program used for the R factor evaluation. This may simply be 'crfac' if the parent directory of this program is in the system PATH variable.
+.PP
+CSEARCH_MAX_EVALS: optional evaluation budget for simplex searches (same as --max-evals).
+.PP
+CSEARCH_MAX_ITERS: optional iteration budget for Powell/annealing searches (same as --max-iters).
+.PP
+CSEARCH_SEED: optional deterministic seed for simulated annealing (same as --seed).
 .PP
 CLEED_PHASE: directory path of the phase shift files used in the surface and bulk models. Please refer to 
 .I phsh(1) 

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -40,6 +40,10 @@ extern "C" {
 extern struct sratom_str *sr_atoms;
 extern struct search_str *sr_search;
 extern char *sr_project;
+extern int sr_amoeba_eval_limit;
+extern int sr_powell_iter_limit;
+extern int sr_sa_iter_limit;
+extern long sa_idum;
 
 /*********************************************************************
  End of include file 

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -16,6 +16,8 @@ extern "C" {
 *********************************************************************/
 
 #include "gh_stddef.h"
+// cppcheck-suppress missingIncludeSystem
+#include <stdint.h>
 
 #define REAL_IS_DOUBLE
 #include "real.h"
@@ -43,7 +45,7 @@ extern char *sr_project;
 extern int sr_amoeba_eval_limit;
 extern int sr_powell_iter_limit;
 extern int sr_sa_iter_limit;
-extern long sa_idum;
+extern uint64_t sa_idum;
 
 /*********************************************************************
  End of include file 

--- a/src/include/search_def.h
+++ b/src/include/search_def.h
@@ -175,6 +175,7 @@ struct search_str
                                    input geometry (used to set up the vertex
                                    for sr_amoeba) */
 #define MAX_ITER_AMOEBA 2000    /* max. number of iterations in sr_amoeba */
+#define MAX_ITER_SA     200     /* max. iterations per temperature in sr_sa */
 
 #define MAX_ITER_POWELL 100     /* max. number of iterations in sr_powell */
 #define BRENT_TOLERANCE 2.0e-2  /* tolerance criterion in function brent 

--- a/src/include/search_optimizer.h
+++ b/src/include/search_optimizer.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+ *                       SEARCH_OPTIMIZER.H
+ *
+ *  Optimizer registry + configuration helpers for SEARCH (csearch).
+ *********************************************************************/
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
+
+#ifndef SEARCH_OPTIMIZER_H
+#define SEARCH_OPTIMIZER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "real.h"
+
+typedef struct sr_optimizer_config {
+  int max_evals;
+  int max_iters;
+  uint64_t seed;
+} sr_optimizer_config;
+
+typedef struct sr_optimizer_def {
+  const char *name;
+  const char *primary;
+  const char *description;
+  const char *aliases_help;
+  int type;
+  int implemented;
+  int uses_delta;
+  int is_default;
+} sr_optimizer_def;
+
+void sr_optimizer_config_init(sr_optimizer_config *cfg);
+void sr_optimizer_config_from_env(sr_optimizer_config *cfg);
+void sr_optimizer_config_apply(const sr_optimizer_config *cfg);
+void sr_optimizer_log_config(FILE *output, const sr_optimizer_config *cfg);
+
+size_t sr_optimizer_count(void);
+const sr_optimizer_def *sr_optimizer_at(size_t index);
+const sr_optimizer_def *sr_optimizer_by_name(const char *name);
+const sr_optimizer_def *sr_optimizer_by_type(int type);
+int sr_optimizer_run(const sr_optimizer_def *opt, const sr_optimizer_config *cfg,
+                     int ndim, real dpos, const char *bak_file,
+                     const char *log_file);
+void sr_optimizer_print_help(FILE *output);
+
+#endif /* SEARCH_OPTIMIZER_H */
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+}
+#endif

--- a/src/include/search_optimizer.h
+++ b/src/include/search_optimizer.h
@@ -11,26 +11,40 @@
 extern "C" {
 #endif
 
+// cppcheck-suppress missingIncludeSystem
 #include <stddef.h>
+// cppcheck-suppress missingIncludeSystem
 #include <stdint.h>
+// cppcheck-suppress missingIncludeSystem
 #include <stdio.h>
 
 #include "real.h"
 
 typedef struct sr_optimizer_config {
+  // cppcheck-suppress unusedStructMember
   int max_evals;
+  // cppcheck-suppress unusedStructMember
   int max_iters;
+  // cppcheck-suppress unusedStructMember
   uint64_t seed;
 } sr_optimizer_config;
 
 typedef struct sr_optimizer_def {
+  // cppcheck-suppress unusedStructMember
   const char *name;
+  // cppcheck-suppress unusedStructMember
   const char *primary;
+  // cppcheck-suppress unusedStructMember
   const char *description;
+  // cppcheck-suppress unusedStructMember
   const char *aliases_help;
+  // cppcheck-suppress unusedStructMember
   int type;
+  // cppcheck-suppress unusedStructMember
   int implemented;
+  // cppcheck-suppress unusedStructMember
   int uses_delta;
+  // cppcheck-suppress unusedStructMember
   int is_default;
 } sr_optimizer_def;
 

--- a/src/include/search_optimizer.h
+++ b/src/include/search_optimizer.h
@@ -4,12 +4,12 @@
  *  Optimizer registry + configuration helpers for SEARCH (csearch).
  *********************************************************************/
 
-#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
-extern "C" {
-#endif
-
 #ifndef SEARCH_OPTIMIZER_H
 #define SEARCH_OPTIMIZER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 #include <stdint.h>
@@ -48,8 +48,8 @@ int sr_optimizer_run(const sr_optimizer_def *opt, const sr_optimizer_config *cfg
                      const char *log_file);
 void sr_optimizer_print_help(FILE *output);
 
-#endif /* SEARCH_OPTIMIZER_H */
-
-#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+#ifdef __cplusplus
 }
 #endif
+
+#endif /* SEARCH_OPTIMIZER_H */

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -37,6 +37,7 @@ SET (searchlib_SRCS
 	    sr_alloc.c
 	    sr_rng.c
 	    sr_parse.c
+	    sr_optimizers.c
 	    sr_simplex.c
 	    sr_vertex_stats.c
 	    sr_amoeba.c

--- a/src/search/Makefile.am
+++ b/src/search/Makefile.am
@@ -17,6 +17,7 @@ libsearch_la_SOURCES =      \
     sr_alloc.c              \
     sr_rng.c                \
     sr_parse.c              \
+    sr_optimizers.c         \
     sr_vertex_stats.c       \
     sr_amoeba.c             \
     sr_amebsa.c             \

--- a/src/search/Makefile.gcc
+++ b/src/search/Makefile.gcc
@@ -53,6 +53,7 @@ FILES.h = $(INCLUDEDIR)/search.h
 SRLIB  =  sr_alloc.o \
           sr_rng.o \
           sr_parse.o \
+          sr_optimizers.o \
           sr_vertex_stats.o \
           sr_amoeba.o \
           sr_amebsa.o \

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -16,6 +16,7 @@ version 0.1
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+// cppcheck-suppress missingIncludeSystem
 #include <limits.h>
 #include <math.h>
 #include "search.h"

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -40,8 +40,11 @@ static const char *sr_consume_arg(int argc, char *argv[], int *i_arg,
 static int sr_parse_positive_int(const char *value, const char *invalid_msg)
 {
   char *end = NULL;
-  long parsed = strtol(value, &end, 10);
-  if (end == value || parsed <= 0 || parsed > INT_MAX) {
+  long parsed;
+
+  errno = 0;
+  parsed = strtol(value, &end, 10);
+  if (end == value || errno == ERANGE || parsed <= 0 || parsed > INT_MAX) {
 #ifdef ERROR
     fprintf(STDERR,"%s", invalid_msg);
 #endif

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -30,7 +30,9 @@ static const char *sr_consume_arg(int argc, char *argv[], int *i_arg,
                                   const char *missing_msg)
 {
   (*i_arg)++;
-  if (*i_arg < argc) return argv[*i_arg];
+  if (*i_arg < argc) {
+    return argv[*i_arg];
+  }
 #ifdef ERROR
   fprintf(STDERR,"%s", missing_msg);
 #endif
@@ -130,32 +132,44 @@ int main(int argc, char *argv[])
 
     /* Read initial displacement */
     if (strncmp(argv[i_arg], "-d", 2) == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): initial displacement value not given\n");
+      const char *value = argv[i_arg] + 2;
+      if (*value == '\0') {
+        value = sr_consume_arg(argc, argv, &i_arg,
+            "*** error (SEARCH): initial displacement value not given\n");
+      }
       delta = (real)atof(value);
       continue;
     }
 
     /* Read parameter input file */
     if (strncmp(argv[i_arg], "-i", 2) == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): no input file specified\n");
+      const char *value = argv[i_arg] + 2;
+      if (*value == '\0') {
+        value = sr_consume_arg(argc, argv, &i_arg,
+            "*** error (SEARCH): no input file specified\n");
+      }
       (void)snprintf(inp_file, sizeof(inp_file), "%s", value);
       continue;
     }
 
     /* Read vertex file */
     if (strncmp(argv[i_arg], "-v", 2) == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): no vertex file specified\n");
+      const char *value = argv[i_arg] + 2;
+      if (*value == '\0') {
+        value = sr_consume_arg(argc, argv, &i_arg,
+            "*** error (SEARCH): no vertex file specified\n");
+      }
       (void)snprintf(bak_file, sizeof(bak_file), "%s", value);
       continue;
     }
 
     /* Read search type */
     if (strncmp(argv[i_arg], "-s", 2) == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): no search algorithm specified\n");
+      const char *value = argv[i_arg] + 2;
+      if (*value == '\0') {
+        value = sr_consume_arg(argc, argv, &i_arg,
+            "*** error (SEARCH): no search algorithm specified\n");
+      }
       optimizer = sr_optimizer_by_name(value);
       if (!optimizer) {
         #ifdef ERROR

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -26,6 +26,46 @@ version 0.1
 
 /**********************************************************************/
 
+static const char *sr_consume_arg(int argc, char *argv[], int *i_arg,
+                                  const char *missing_msg)
+{
+  (*i_arg)++;
+  if (*i_arg < argc) return argv[*i_arg];
+#ifdef ERROR
+  fprintf(STDERR,"%s", missing_msg);
+#endif
+  exit(1);
+}
+
+static int sr_parse_positive_int(const char *value, const char *invalid_msg)
+{
+  char *end = NULL;
+  long parsed = strtol(value, &end, 10);
+  if (end == value || parsed <= 0 || parsed > INT_MAX) {
+#ifdef ERROR
+    fprintf(STDERR,"%s", invalid_msg);
+#endif
+    exit(1);
+  }
+  return (int)parsed;
+}
+
+static uint64_t sr_parse_seed(const char *value, const char *invalid_msg)
+{
+  char *end = NULL;
+  unsigned long long parsed;
+
+  errno = 0;
+  parsed = strtoull(value, &end, 10);
+  if (end == value || errno == ERANGE) {
+#ifdef ERROR
+    fprintf(STDERR,"%s", invalid_msg);
+#endif
+    exit(1);
+  }
+  return (uint64_t)parsed;
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -76,7 +116,7 @@ int main(int argc, char *argv[])
   
   for (i_arg = 1; i_arg < argc; i_arg++)
   {
-    if(*argv[i_arg] != '-')
+    if (argv[i_arg][0] != '-')
     {
       #ifdef ERROR
       fprintf(STDERR,"*** error (SEARCH):\tsyntax error:\n");
@@ -84,160 +124,84 @@ int main(int argc, char *argv[])
       #endif
       exit(1);
     }
-    else
-    {
 
-      /* Read initial displacement */
-      if(strncmp(argv[i_arg], "-d", 2) == 0)
-      {
-        i_arg++;
-        if (i_arg < argc)
-          delta = (real)atof(argv[i_arg]);
-        else 
-        {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): initial displacement value not given\n");
-          #endif
-          exit(1);
-        }
-      }
+    /* Read initial displacement */
+    if (strncmp(argv[i_arg], "-d", 2) == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): initial displacement value not given\n");
+      delta = (real)atof(value);
+      continue;
+    }
 
-      /* Read parameter input file */
-      if(strncmp(argv[i_arg], "-i", 2) == 0)
-      {
-        i_arg++;
-        if (i_arg < argc)
-            (void)snprintf(inp_file, sizeof(inp_file), "%s", argv[i_arg]);
-        else 
-        {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): no input file specified\n");
-          #endif
-          exit(1);
-        }
-      }
+    /* Read parameter input file */
+    if (strncmp(argv[i_arg], "-i", 2) == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): no input file specified\n");
+      (void)snprintf(inp_file, sizeof(inp_file), "%s", value);
+      continue;
+    }
 
-      /* Read vertex file */
-      if(strncmp(argv[i_arg], "-v", 2) == 0)
-      {
-        i_arg++;
-        if (i_arg < argc)
-            (void)snprintf(bak_file, sizeof(bak_file), "%s", argv[i_arg]);
-        else
-        {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): no vertex file specified\n");
-          #endif
-          exit(1);
-        }
-      }
+    /* Read vertex file */
+    if (strncmp(argv[i_arg], "-v", 2) == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): no vertex file specified\n");
+      (void)snprintf(bak_file, sizeof(bak_file), "%s", value);
+      continue;
+    }
 
-      /* Read search type */
-      if(strncmp(argv[i_arg], "-s", 2) == 0)
-      {
-        i_arg++;
-        if (i_arg >= argc) 
-        {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): no search algorithm specified\n");
-          #endif
-          exit(1);
-        }
-        optimizer = sr_optimizer_by_name(argv[i_arg]);
-        if (!optimizer)
-        {
-          #ifdef ERROR
-          fprintf(STDERR,
-             "*** error (SEARCH): unknown search type \"%s\" (option -s)\n",
-             argv[i_arg]);
-          #endif
-          exit(1);
-        }
-        
-      } /* search type */
+    /* Read search type */
+    if (strncmp(argv[i_arg], "-s", 2) == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): no search algorithm specified\n");
+      optimizer = sr_optimizer_by_name(value);
+      if (!optimizer) {
+        #ifdef ERROR
+        fprintf(STDERR,
+           "*** error (SEARCH): unknown search type \"%s\" (option -s)\n",
+           value);
+        #endif
+        exit(1);
+      }
+      continue;
+    }
 
-      else if (strcmp(argv[i_arg], "--max-evals") == 0)
-      {
-        char *end = NULL;
-        long val;
-        i_arg++;
-        if (i_arg < argc) {
-          val = strtol(argv[i_arg], &end, 10);
-          if (end == argv[i_arg] || val <= 0 || val > INT_MAX) {
-            #ifdef ERROR
-            fprintf(STDERR,"*** error (SEARCH): invalid max evals value\n");
-            #endif
-            exit(1);
-          }
-          opt_cfg.max_evals = (int)val;
-        } else {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): max evals value not given\n");
-          #endif
-          exit(1);
-        }
-      }
+    if (strcmp(argv[i_arg], "--max-evals") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): max evals value not given\n");
+      opt_cfg.max_evals = sr_parse_positive_int(value,
+          "*** error (SEARCH): invalid max evals value\n");
+      continue;
+    }
 
-      else if (strcmp(argv[i_arg], "--max-iters") == 0)
-      {
-        char *end = NULL;
-        long val;
-        i_arg++;
-        if (i_arg < argc) {
-          val = strtol(argv[i_arg], &end, 10);
-          if (end == argv[i_arg] || val <= 0 || val > INT_MAX) {
-            #ifdef ERROR
-            fprintf(STDERR,"*** error (SEARCH): invalid max iters value\n");
-            #endif
-            exit(1);
-          }
-          opt_cfg.max_iters = (int)val;
-        } else {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): max iters value not given\n");
-          #endif
-          exit(1);
-        }
-      }
+    if (strcmp(argv[i_arg], "--max-iters") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): max iters value not given\n");
+      opt_cfg.max_iters = sr_parse_positive_int(value,
+          "*** error (SEARCH): invalid max iters value\n");
+      continue;
+    }
 
-      else if (strcmp(argv[i_arg], "--seed") == 0)
-      {
-        char *end = NULL;
-        i_arg++;
-        if (i_arg < argc) {
-          errno = 0;
-          opt_cfg.seed = strtoull(argv[i_arg], &end, 10);
-          if (end == argv[i_arg] || errno == ERANGE) {
-            #ifdef ERROR
-            fprintf(STDERR,"*** error (SEARCH): invalid seed value\n");
-            #endif
-            exit(1);
-          }
-        } else {
-          #ifdef ERROR
-          fprintf(STDERR,"*** error (SEARCH): seed value not given\n");
-          #endif
-          exit(1);
-        }
-      }
-      
-      /* help */
-      else if ((strcmp(argv[i_arg], "-h") == 0) || 
-          (strcmp(argv[i_arg], "--help") == 0))
-      {
-        search_usage(STDOUT);
-        exit(0);
-      }
-      
-      /* version information */
-      else if ((strcmp(argv[i_arg], "-V") == 0) ||
-           (strcmp(argv[i_arg], "--version") == 0))
-      {
-        search_info();
-        exit(0);
-      }
+    if (strcmp(argv[i_arg], "--seed") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): seed value not given\n");
+      opt_cfg.seed = sr_parse_seed(value,
+          "*** error (SEARCH): invalid seed value\n");
+      continue;
+    }
 
-    } /* else */
+    /* help */
+    if ((strcmp(argv[i_arg], "-h") == 0) ||
+        (strcmp(argv[i_arg], "--help") == 0)) {
+      search_usage(STDOUT);
+      exit(0);
+    }
+
+    /* version information */
+    if ((strcmp(argv[i_arg], "-V") == 0) ||
+        (strcmp(argv[i_arg], "--version") == 0)) {
+      search_info();
+      exit(0);
+    }
   
   }  /* for i_arg */
 

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -16,6 +16,7 @@ version 0.1
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <math.h>
 #include "search.h"
 #include "search_optimizer.h"
@@ -152,11 +153,20 @@ int main(int argc, char *argv[])
         
       } /* search type */
 
-      if (strcmp(argv[i_arg], "--max-evals") == 0)
+      else if (strcmp(argv[i_arg], "--max-evals") == 0)
       {
+        char *end = NULL;
+        long val;
         i_arg++;
         if (i_arg < argc) {
-          opt_cfg.max_evals = atoi(argv[i_arg]);
+          val = strtol(argv[i_arg], &end, 10);
+          if (end == argv[i_arg] || val <= 0 || val > INT_MAX) {
+            #ifdef ERROR
+            fprintf(STDERR,"*** error (SEARCH): invalid max evals value\n");
+            #endif
+            exit(1);
+          }
+          opt_cfg.max_evals = (int)val;
         } else {
           #ifdef ERROR
           fprintf(STDERR,"*** error (SEARCH): max evals value not given\n");
@@ -165,11 +175,20 @@ int main(int argc, char *argv[])
         }
       }
 
-      if (strcmp(argv[i_arg], "--max-iters") == 0)
+      else if (strcmp(argv[i_arg], "--max-iters") == 0)
       {
+        char *end = NULL;
+        long val;
         i_arg++;
         if (i_arg < argc) {
-          opt_cfg.max_iters = atoi(argv[i_arg]);
+          val = strtol(argv[i_arg], &end, 10);
+          if (end == argv[i_arg] || val <= 0 || val > INT_MAX) {
+            #ifdef ERROR
+            fprintf(STDERR,"*** error (SEARCH): invalid max iters value\n");
+            #endif
+            exit(1);
+          }
+          opt_cfg.max_iters = (int)val;
         } else {
           #ifdef ERROR
           fprintf(STDERR,"*** error (SEARCH): max iters value not given\n");
@@ -178,7 +197,7 @@ int main(int argc, char *argv[])
         }
       }
 
-      if (strcmp(argv[i_arg], "--seed") == 0)
+      else if (strcmp(argv[i_arg], "--seed") == 0)
       {
         char *end = NULL;
         i_arg++;
@@ -199,7 +218,7 @@ int main(int argc, char *argv[])
       }
       
       /* help */
-      if ((strcmp(argv[i_arg], "-h") == 0) || 
+      else if ((strcmp(argv[i_arg], "-h") == 0) || 
           (strcmp(argv[i_arg], "--help") == 0))
       {
         search_usage(STDOUT);
@@ -207,7 +226,7 @@ int main(int argc, char *argv[])
       }
       
       /* version information */
-      if ((strcmp(argv[i_arg], "-V") == 0) ||
+      else if ((strcmp(argv[i_arg], "-V") == 0) ||
            (strcmp(argv[i_arg], "--version") == 0))
       {
         search_info();

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -18,6 +18,8 @@ version 0.1
 #include <string.h>
 // cppcheck-suppress missingIncludeSystem
 #include <limits.h>
+// cppcheck-suppress missingIncludeSystem
+#include <errno.h>
 #include <math.h>
 #include "search.h"
 #include "search_optimizer.h"
@@ -203,8 +205,9 @@ int main(int argc, char *argv[])
         char *end = NULL;
         i_arg++;
         if (i_arg < argc) {
+          errno = 0;
           opt_cfg.seed = strtoull(argv[i_arg], &end, 10);
-          if (end == argv[i_arg]) {
+          if (end == argv[i_arg] || errno == ERANGE) {
             #ifdef ERROR
             fprintf(STDERR,"*** error (SEARCH): invalid seed value\n");
             #endif

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
   if (!optimizer) {
     optimizer = sr_optimizer_by_type(SR_SIMPLEX);
   }
-  if (!optimizer || sr_optimizer_run(optimizer, &opt_cfg, ndim, delta, bak_file, log_file) != 0)
+  if (sr_optimizer_run(optimizer, &opt_cfg, ndim, delta, bak_file, log_file) != 0)
   {
     #ifdef ERROR
     fprintf(STDERR,

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -13,6 +13,8 @@ LD/29.06.2014 - Creation of open source version of ran1 function
 ***********************************************************************/
 #include "real.h"
 // cppcheck-suppress missingIncludeSystem
+#include <limits.h>
+// cppcheck-suppress missingIncludeSystem
 #include <stdint.h>
 
 /**
@@ -54,13 +56,21 @@ real ran1(long *idum)
     /* Initialize or reseed when idum is negative or state is zero */
     if (*idum < 0 || ran1_state == 0) {
         /* Use absolute value of idum as seed; ensure non-zero state */
-        uint64_t seed = (uint64_t)(*idum < 0 ? -(*idum) : *idum);
+        uint64_t seed = (uint64_t)(*idum);
+        if (*idum < 0) {
+            /* Avoid signed overflow when idum == LONG_MIN. */
+            seed = (uint64_t)(0 - seed);
+        }
         ran1_state = (seed == 0) ? UINT64_C(0x853c49e6748fea9b) : seed;
         /* Warm up the generator */
         (void)ran1_next64();
         /* Convention: set idum positive after initialization */
         if (*idum < 0) {
-            *idum = -(*idum);
+            if (*idum == LONG_MIN) {
+                *idum = LONG_MAX;
+            } else {
+                *idum = -(*idum);
+            }
         }
     }
 

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -19,7 +19,7 @@ LD/29.06.2014 - Creation of open source version of ran1 function
  *
  * This implementation uses the xorshift64* algorithm (Vigna 2016), which
  * provides better statistical properties and portability compared to libc
- * rand(). The state is thread-local to avoid issues in multi-threaded use.
+ * rand(). The state is module-static (not thread-safe without external sync).
  */
 static uint64_t ran1_state = 0;
 
@@ -58,11 +58,13 @@ real ran1(long *idum)
         /* Warm up the generator */
         (void)ran1_next64();
         /* Convention: set idum positive after initialization */
-        if (*idum < 0) *idum = -(*idum);
+        if (*idum < 0) {
+            *idum = -(*idum);
+        }
     }
 
-    /* Produce a random number in (0.0, 1.0) */
+    /* Produce a random number in (0.0, 1.0) exclusive */
     uint64_t u = ran1_next64();
-    /* Use upper 53 bits for best quality, scale to [0, 1) */
-    return (real)((u >> 11) * (1.0 / 9007199254740992.0));
+    /* Map [0, 2^53-1] -> [1, 2^53] -> (0, 1) exclusive of endpoints */
+    return (real)(((u >> 11) + 1) * (1.0 / 9007199254740994.0));
 }

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -4,34 +4,65 @@ file contains function:
 
   real ran1(long *idum)
 
- random number generator of Park and Miller using minstd 
+ random number generator of Park and Miller using minstd
  function from GSL
 
  Changes:
 LD/29.06.2014 - Creation of open source version of ran1 function
+2026-01-09    - Replace rand()/srand() with portable xorshift64 algorithm
 ***********************************************************************/
 #include "real.h"
-#include <stdlib.h>
+#include <stdint.h>
+
+/**
+ * @brief Internal state for the xorshift64* PRNG.
+ *
+ * This implementation uses the xorshift64* algorithm (Vigna 2016), which
+ * provides better statistical properties and portability compared to libc
+ * rand(). The state is thread-local to avoid issues in multi-threaded use.
+ */
+static uint64_t ran1_state = 0;
+
+/**
+ * @brief Advance the xorshift64* PRNG and return next 64-bit value.
+ */
+static uint64_t ran1_next64(void)
+{
+  uint64_t s = ran1_state;
+  s ^= s >> 12;
+  s ^= s << 25;
+  s ^= s >> 27;
+  ran1_state = s;
+  return s * UINT64_C(0x2545F4914F6CDD1D);
+}
 
 real ran1(long *idum)
 
 /************************************************************************
 
- Minimal random number generator by Park and Miller with Bays-Durham 
+ Minimal random number generator by Park and Miller with Bays-Durham
  shuffle and added safeguards. Returns a uniform random deviate between
- 0.0 and 1.0 (exclusive of the endpointvalues). 
+ 0.0 and 1.0 (exclusive of the endpointvalues).
 
- Call with idum a negative integer to initialize; thereafter do not 
- alter idum inbetween successive deviates in a sequence. RNMX should 
+ Call with idum a negative integer to initialize; thereafter do not
+ alter idum inbetween successive deviates in a sequence. RNMX should
  approximate the largest floating value that is less than 1.0.
 
 ************************************************************************/
-{   
-    /* initialise the random number generator from seed */
-    //time_t t;
-    //srand((unsigned) time(&t));
-    srand((unsigned long) *idum); 
-    
-    /* produce a random number between 0. and 1. */
-    return (real) rand()/RAND_MAX;
+{
+    /* Initialize or reseed when idum is negative or state is zero */
+    if (*idum < 0 || ran1_state == 0) {
+        /* Use absolute value of idum as seed; ensure non-zero state */
+        uint64_t seed = (uint64_t)(*idum < 0 ? -(*idum) : *idum);
+        ran1_state = (seed == 0) ? UINT64_C(0x853c49e6748fea9b) : seed;
+        /* Warm up the generator */
+        (void)ran1_next64();
+        /* Convention: set idum positive after initialization */
+        if (*idum < 0) *idum = -(*idum);
+    }
+
+    /* Produce a random number in (0.0, 1.0) */
+    uint64_t u = ran1_next64();
+    /* Use upper 53 bits for best quality, scale to [0, 1) */
+    return (real)((u >> 11) * (1.0 / 9007199254740992.0));
 }

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -4,8 +4,8 @@ file contains function:
 
   real ran1(long *idum)
 
- random number generator of Park and Miller using minstd
- function from GSL
+ xorshift64* pseudorandom number generator with a 64-bit state
+ stored in ran1_state (seeded via the idum input).
 
  Changes:
 LD/29.06.2014 - Creation of open source version of ran1 function

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -56,10 +56,10 @@ real ran1(long *idum)
     /* Initialize or reseed when idum is negative or state is zero */
     if (*idum < 0 || ran1_state == 0) {
         /* Use absolute value of idum as seed; ensure non-zero state */
-        uint64_t seed = (uint64_t)(*idum);
+        uint64_t seed = *idum;
         if (*idum < 0) {
             /* Avoid signed overflow when idum == LONG_MIN. */
-            seed = (uint64_t)(0 - seed);
+            seed = 0 - seed;
         }
         ran1_state = (seed == 0) ? UINT64_C(0x853c49e6748fea9b) : seed;
         /* Warm up the generator */

--- a/src/search/ran1.c
+++ b/src/search/ran1.c
@@ -12,6 +12,7 @@ LD/29.06.2014 - Creation of open source version of ran1 function
 2026-01-09    - Replace rand()/srand() with portable xorshift64 algorithm
 ***********************************************************************/
 #include "real.h"
+// cppcheck-suppress missingIncludeSystem
 #include <stdint.h>
 
 /**

--- a/src/search/search_globals.c
+++ b/src/search/search_globals.c
@@ -10,4 +10,6 @@ exactly once (and declared as extern in headers).
 struct sratom_str *sr_atoms = NULL;
 struct search_str *sr_search = NULL;
 char *sr_project = NULL;
-
+int sr_amoeba_eval_limit = MAX_ITER_AMOEBA;
+int sr_powell_iter_limit = MAX_ITER_POWELL;
+int sr_sa_iter_limit = MAX_ITER_SA;

--- a/src/search/sr_amebsa.c
+++ b/src/search/sr_amebsa.c
@@ -30,7 +30,7 @@
 #include "sr_simplex.h"
 
 /* The SEARCH driver keeps a global seed. */
-extern long sa_idum;
+extern uint64_t sa_idum;
 
 static int sr_accept_move(sr_rng *rng, real current, real proposed, real temp)
 {
@@ -75,10 +75,9 @@ static int sr_amebsa_validate_inputs(real **p, real *y, int ndim, real *pb, real
   return 0;
 }
 
-static uint64_t sr_amebsa_seed_from_idum(long idum)
+static uint64_t sr_amebsa_seed_from_idum(uint64_t idum)
 {
-  uint64_t seed = (idum < 0) ? (uint64_t)(-idum) : (uint64_t)idum;
-  return (seed == 0) ? 1 : seed;
+  return idum;
 }
 
 static int sr_amebsa_alloc(sr_amebsa_ctx *ctx)
@@ -178,7 +177,7 @@ static void sr_amebsa_run(sr_amebsa_ctx *ctx)
 static void sr_amebsa_finalize(sr_amebsa_ctx *ctx)
 {
   *ctx->iter_io = ctx->used;
-  sa_idum = (long)(ctx->seed + (uint64_t)ctx->used + 1);
+  sa_idum = ctx->seed + (uint64_t)ctx->used + 1;
   sr_amebsa_init_best(ctx);
 }
 

--- a/src/search/sr_amoeba.c
+++ b/src/search/sr_amoeba.c
@@ -97,6 +97,7 @@ typedef struct sr_amoeba_ctx {
   real ftol;
   real (*funk)(real *);
   int *nfunk;
+  int max_evals;
   real **p;
   real *y;
   real *centroid;
@@ -185,7 +186,7 @@ static int sr_amoeba_step(sr_amoeba_ctx *ctx)
   sr_simplex_extremes(ctx->y, ctx->ndim, &ilo, &ihi, &inhi);
 
   if (sr_amoeba_converged(ctx, ilo, ihi)) return 1;
-  if (*ctx->nfunk >= MAX_ITER_AMOEBA) return -2;
+  if (*ctx->nfunk >= ctx->max_evals) return -2;
 
   sr_simplex_centroid_excluding((const real **)ctx->p, ctx->centroid, ctx->ndim, ihi);
   real fr = sr_amoeba_reflect(ctx, ihi);
@@ -227,6 +228,7 @@ static int sr_amoeba_init(sr_amoeba_ctx *ctx, real **p, real *y, int ndim,
   ctx->ftol = ftol;
   ctx->funk = funk;
   ctx->nfunk = nfunk;
+  ctx->max_evals = sr_amoeba_eval_limit > 0 ? sr_amoeba_eval_limit : MAX_ITER_AMOEBA;
   ctx->p = p;
   ctx->y = y;
   ctx->centroid = NULL;

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -1,0 +1,311 @@
+/*********************************************************************
+ *                       SR_OPTIMIZERS.C
+ *
+ *  Optimizer registry + configuration helpers for SEARCH (csearch).
+ *********************************************************************/
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "search.h"
+#include "search_optimizer.h"
+
+typedef int (*sr_optimizer_run_fn)(int ndim, real dpos, const char *bak_file,
+                                   const char *log_file);
+
+typedef struct sr_optimizer_entry {
+  sr_optimizer_def def;
+  const char *aliases[8];
+  sr_optimizer_run_fn run;
+} sr_optimizer_entry;
+
+static int sr_run_simplex(int ndim, real dpos, const char *bak_file,
+                          const char *log_file)
+{
+  SR_SX(ndim, dpos, bak_file, log_file);
+  return 0;
+}
+
+static int sr_run_powell(int ndim, real dpos, const char *bak_file,
+                         const char *log_file)
+{
+  (void)dpos;
+  SR_PO(ndim, bak_file, log_file);
+  return 0;
+}
+
+static int sr_run_sa(int ndim, real dpos, const char *bak_file,
+                     const char *log_file)
+{
+  SR_SA(ndim, dpos, bak_file, log_file);
+  return 0;
+}
+
+static int sr_run_ga(int ndim, real dpos, const char *bak_file,
+                     const char *log_file)
+{
+  (void)ndim;
+  (void)dpos;
+  (void)bak_file;
+  (void)log_file;
+  SR_NOT_IMPLEMENTED_ERROR("genetic algorithm");
+  return -1;
+}
+
+static const sr_optimizer_entry sr_optimizers[] = {
+    {
+        .def = {
+            .name = "simplex",
+            .primary = "si",
+            .description = "simplex method",
+            .aliases_help = "sx, simplex",
+            .type = SR_SIMPLEX,
+            .implemented = 1,
+            .uses_delta = 1,
+            .is_default = 1,
+        },
+        .aliases = {"si", "sx", "simplex", NULL},
+        .run = sr_run_simplex,
+    },
+    {
+        .def = {
+            .name = "powell",
+            .primary = "po",
+            .description = "Powell's method",
+            .aliases_help = "powell",
+            .type = SR_POWELL,
+            .implemented = 1,
+            .uses_delta = 0,
+            .is_default = 0,
+        },
+        .aliases = {"po", "powell", NULL},
+        .run = sr_run_powell,
+    },
+    {
+        .def = {
+            .name = "annealing",
+            .primary = "sa",
+            .description = "simulated annealing",
+            .aliases_help = "anneal, annealing",
+            .type = SR_SIM_ANNEALING,
+            .implemented = 1,
+            .uses_delta = 1,
+            .is_default = 0,
+        },
+        .aliases = {"sa", "anneal", "annealing", "simulated", "simulated-annealing", NULL},
+        .run = sr_run_sa,
+    },
+    {
+        .def = {
+            .name = "genetic",
+            .primary = "ga",
+            .description = "genetic algorithm",
+            .aliases_help = "genetic",
+            .type = SR_GENETIC,
+            .implemented = 0,
+            .uses_delta = 0,
+            .is_default = 0,
+        },
+        .aliases = {"ga", "genetic", "genetic-algorithm", NULL},
+        .run = sr_run_ga,
+    },
+};
+
+static const sr_optimizer_entry *sr_optimizer_entry_by_type(int type)
+{
+  size_t i;
+  for (i = 0; i < sr_optimizer_count(); i++) {
+    if (sr_optimizers[i].def.type == type) {
+      return &sr_optimizers[i];
+    }
+  }
+  return NULL;
+}
+
+static int sr_optimizer_matches(const char *name,
+                                const sr_optimizer_entry *entry)
+{
+  size_t i;
+  if (!name || !entry) {
+    return 0;
+  }
+  for (i = 0; entry->aliases[i] != NULL; i++) {
+    const char *alias = entry->aliases[i];
+    size_t len = strlen(alias);
+    if (len == 0) {
+      continue;
+    }
+    if (strncasecmp(name, alias, len) == 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void sr_optimizer_config_init(sr_optimizer_config *cfg)
+{
+  if (!cfg) return;
+  cfg->max_evals = 0;
+  cfg->max_iters = 0;
+  cfg->seed = 0;
+}
+
+static int sr_optimizer_read_int_env(const char *name, int *out_value)
+{
+  char *end = NULL;
+  const char *raw = getenv(name);
+  long parsed = 0;
+
+  if (!raw || !out_value) return 0;
+  parsed = strtol(raw, &end, 10);
+  if (end == raw || parsed <= 0) return 0;
+  *out_value = (int)parsed;
+  return 1;
+}
+
+static int sr_optimizer_read_seed_env(const char *name, uint64_t *out_value)
+{
+  char *end = NULL;
+  const char *raw = getenv(name);
+  unsigned long long parsed = 0;
+
+  if (!raw || !out_value) return 0;
+  parsed = strtoull(raw, &end, 10);
+  if (end == raw || parsed == 0) return 0;
+  *out_value = (uint64_t)parsed;
+  return 1;
+}
+
+void sr_optimizer_config_from_env(sr_optimizer_config *cfg)
+{
+  if (!cfg) return;
+  (void)sr_optimizer_read_int_env("CSEARCH_MAX_EVALS", &cfg->max_evals);
+  (void)sr_optimizer_read_int_env("CSEARCH_MAX_ITERS", &cfg->max_iters);
+  (void)sr_optimizer_read_seed_env("CSEARCH_SEED", &cfg->seed);
+}
+
+void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
+{
+  if (!cfg) return;
+  if (cfg->max_evals > 0) {
+    sr_amoeba_eval_limit = cfg->max_evals;
+  }
+  if (cfg->max_iters > 0) {
+    sr_powell_iter_limit = cfg->max_iters;
+    sr_sa_iter_limit = cfg->max_iters;
+    if (cfg->max_evals <= 0) {
+      sr_amoeba_eval_limit = cfg->max_iters;
+    }
+  }
+  if (cfg->seed > 0) {
+    sa_idum = (long)(cfg->seed > (uint64_t)LONG_MAX ? LONG_MAX : cfg->seed);
+    sa_idum = -sa_idum;
+  }
+}
+
+void sr_optimizer_log_config(FILE *output, const sr_optimizer_config *cfg)
+{
+  if (!output || !cfg) return;
+
+  fprintf(output, "=> Optimizer config:");
+  if (cfg->max_evals <= 0 && cfg->max_iters <= 0 && cfg->seed == 0) {
+    fprintf(output, " defaults\n");
+    return;
+  }
+
+  if (cfg->max_evals > 0) {
+    fprintf(output, " max_evals=%d", cfg->max_evals);
+  } else {
+    fprintf(output, " max_evals=default");
+  }
+
+  if (cfg->max_iters > 0) {
+    fprintf(output, " max_iters=%d", cfg->max_iters);
+  } else {
+    fprintf(output, " max_iters=default");
+  }
+
+  if (cfg->seed > 0) {
+    fprintf(output, " seed=%llu", (unsigned long long)cfg->seed);
+  } else {
+    fprintf(output, " seed=default");
+  }
+
+  fprintf(output, "\n");
+}
+
+size_t sr_optimizer_count(void)
+{
+  return sizeof(sr_optimizers) / sizeof(sr_optimizers[0]);
+}
+
+const sr_optimizer_def *sr_optimizer_at(size_t index)
+{
+  if (index >= sr_optimizer_count()) {
+    return NULL;
+  }
+  return &sr_optimizers[index].def;
+}
+
+const sr_optimizer_def *sr_optimizer_by_name(const char *name)
+{
+  size_t i;
+  if (!name) {
+    return NULL;
+  }
+  for (i = 0; i < sr_optimizer_count(); i++) {
+    if (sr_optimizer_matches(name, &sr_optimizers[i])) {
+      return &sr_optimizers[i].def;
+    }
+  }
+  return NULL;
+}
+
+const sr_optimizer_def *sr_optimizer_by_type(int type)
+{
+  const sr_optimizer_entry *entry = sr_optimizer_entry_by_type(type);
+  return entry ? &entry->def : NULL;
+}
+
+int sr_optimizer_run(const sr_optimizer_def *opt, const sr_optimizer_config *cfg,
+                     int ndim, real dpos, const char *bak_file,
+                     const char *log_file)
+{
+  const sr_optimizer_entry *entry = NULL;
+  if (!opt) {
+    return -1;
+  }
+
+  entry = sr_optimizer_entry_by_type(opt->type);
+  if (!entry || !entry->run) {
+    return -1;
+  }
+
+  sr_optimizer_config_apply(cfg);
+  return entry->run(ndim, dpos, bak_file, log_file);
+}
+
+void sr_optimizer_print_help(FILE *output)
+{
+  size_t i;
+  if (!output) {
+    return;
+  }
+  for (i = 0; i < sr_optimizer_count(); i++) {
+    const sr_optimizer_def *def = &sr_optimizers[i].def;
+    fprintf(output, "                          '%s' = %s",
+            def->primary, def->description);
+    if (def->aliases_help && def->aliases_help[0] != '\0') {
+      fprintf(output, " (aliases: %s)", def->aliases_help);
+    }
+    if (!def->implemented) {
+      fprintf(output, " (not implemented)");
+    }
+    if (def->is_default) {
+      fprintf(output, " (default)");
+    }
+    fprintf(output, "\n");
+  }
+}

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -195,16 +195,15 @@ void sr_optimizer_config_from_env(sr_optimizer_config *cfg)
 void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
 {
   if (!cfg) return;
-  if (cfg->max_evals > 0) {
-    sr_amoeba_eval_limit = cfg->max_evals;
-  }
+  sr_amoeba_eval_limit = (cfg->max_evals > 0) ? cfg->max_evals : MAX_ITER_AMOEBA;
   if (cfg->max_iters > 0) {
     sr_powell_iter_limit = cfg->max_iters;
     sr_sa_iter_limit = cfg->max_iters;
+  } else {
+    sr_powell_iter_limit = MAX_ITER_POWELL;
+    sr_sa_iter_limit = MAX_ITER_SA;
   }
-  if (cfg->seed > 0) {
-    sa_idum = cfg->seed;
-  }
+  sa_idum = (cfg->seed > 0) ? cfg->seed : 0;
 }
 
 static int sr_optimizer_config_is_default(const sr_optimizer_config *cfg)

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -28,7 +28,6 @@ typedef struct sr_optimizer_entry {
 static int sr_run_simplex(int ndim, real dpos, const char *bak_file,
                           const char *log_file)
 {
-  (void)dpos;
   SR_SX(ndim, dpos, bak_file, log_file);
   return 0;
 }

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -133,11 +133,10 @@ static int sr_optimizer_matches(const char *name,
   }
   for (i = 0; entry->aliases[i] != NULL; i++) {
     const char *alias = entry->aliases[i];
-    size_t len = strlen(alias);
-    if (len == 0) {
+    if (alias[0] == '\0') {
       continue;
     }
-    if (strncasecmp(name, alias, len) == 0) {
+    if (strcasecmp(name, alias) == 0) {
       return 1;
     }
   }
@@ -158,9 +157,13 @@ static int sr_optimizer_read_int_env(const char *name, int *out_value)
   const char *raw = getenv(name);
   long parsed = 0;
 
-  if (!raw || !out_value) return 0;
+  if (!raw || !out_value) {
+    return 0;
+  }
   parsed = strtol(raw, &end, 10);
-  if (end == raw || parsed <= 0) return 0;
+  if (end == raw || parsed <= 0 || parsed > INT_MAX) {
+    return 0;
+  }
   *out_value = (int)parsed;
   return 1;
 }

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -119,8 +119,7 @@ static const sr_optimizer_entry sr_optimizers[] = {
 
 static const sr_optimizer_entry *sr_optimizer_entry_by_type(int type)
 {
-  size_t i;
-  for (i = 0; i < sr_optimizer_count(); i++) {
+  for (size_t i = 0; i < sr_optimizer_count(); i++) {
     if (sr_optimizers[i].def.type == type) {
       return &sr_optimizers[i];
     }
@@ -131,11 +130,10 @@ static const sr_optimizer_entry *sr_optimizer_entry_by_type(int type)
 static int sr_optimizer_matches(const char *name,
                                 const sr_optimizer_entry *entry)
 {
-  size_t i;
   if (!name || !entry) {
     return 0;
   }
-  for (i = 0; entry->aliases[i] != NULL; i++) {
+  for (size_t i = 0; entry->aliases[i] != NULL; i++) {
     const char *alias = entry->aliases[i];
     if (alias[0] == '\0') {
       continue;

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -207,8 +207,7 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
     }
   }
   if (cfg->seed > 0) {
-    sa_idum = (long)(cfg->seed > (uint64_t)LONG_MAX ? LONG_MAX : cfg->seed);
-    sa_idum = -sa_idum;
+    sa_idum = cfg->seed;
   }
 }
 

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -180,9 +180,10 @@ static int sr_optimizer_read_seed_env(const char *name, uint64_t *out_value)
   unsigned long long parsed = 0;
 
   if (!raw || !out_value) return 0;
+  errno = 0;
   parsed = strtoull(raw, &end, 10);
   /* CSEARCH_SEED=0 means "use the default seed", so ignore it here. */
-  if (end == raw || parsed == 0) return 0;
+  if (end == raw || errno == ERANGE || parsed == 0) return 0;
   *out_value = (uint64_t)parsed;
   return 1;
 }

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -12,6 +12,8 @@
 #include <string.h>
 // cppcheck-suppress missingIncludeSystem
 #include <strings.h>
+// cppcheck-suppress missingIncludeSystem
+#include <errno.h>
 
 #include "search.h"
 #include "search_optimizer.h"
@@ -162,8 +164,9 @@ static int sr_optimizer_read_int_env(const char *name, int *out_value)
   if (!raw || !out_value) {
     return 0;
   }
+  errno = 0;
   parsed = strtol(raw, &end, 10);
-  if (end == raw || parsed <= 0 || parsed > INT_MAX) {
+  if (end == raw || errno == ERANGE || parsed <= 0 || parsed > INT_MAX) {
     return 0;
   }
   *out_value = (int)parsed;

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -4,9 +4,13 @@
  *  Optimizer registry + configuration helpers for SEARCH (csearch).
  *********************************************************************/
 
+// cppcheck-suppress missingIncludeSystem
 #include <limits.h>
+// cppcheck-suppress missingIncludeSystem
 #include <stdlib.h>
+// cppcheck-suppress missingIncludeSystem
 #include <string.h>
+// cppcheck-suppress missingIncludeSystem
 #include <strings.h>
 
 #include "search.h"
@@ -208,33 +212,49 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
   }
 }
 
+static int sr_optimizer_config_is_default(const sr_optimizer_config *cfg)
+{
+  if (!cfg) return 1;
+  if (cfg->max_evals > 0) return 0;
+  if (cfg->max_iters > 0) return 0;
+  if (cfg->seed != 0) return 0;
+  return 1;
+}
+
+static void sr_optimizer_log_int(FILE *output, const char *label, int value)
+{
+  if (!output || !label) return;
+  if (value > 0) {
+    fprintf(output, " %s=%d", label, value);
+  } else {
+    fprintf(output, " %s=default", label);
+  }
+}
+
+static void sr_optimizer_log_seed(FILE *output, const char *label, uint64_t value)
+{
+  if (!output || !label) return;
+  if (value > 0) {
+    fprintf(output, " %s=%llu", label, (unsigned long long)value);
+  } else {
+    fprintf(output, " %s=default", label);
+  }
+}
+
 void sr_optimizer_log_config(FILE *output, const sr_optimizer_config *cfg)
 {
-  if (!output || !cfg) return;
+  if (!output) return;
+  if (!cfg) return;
 
   fprintf(output, "=> Optimizer config:");
-  if (cfg->max_evals <= 0 && cfg->max_iters <= 0 && cfg->seed == 0) {
+  if (sr_optimizer_config_is_default(cfg)) {
     fprintf(output, " defaults\n");
     return;
   }
 
-  if (cfg->max_evals > 0) {
-    fprintf(output, " max_evals=%d", cfg->max_evals);
-  } else {
-    fprintf(output, " max_evals=default");
-  }
-
-  if (cfg->max_iters > 0) {
-    fprintf(output, " max_iters=%d", cfg->max_iters);
-  } else {
-    fprintf(output, " max_iters=default");
-  }
-
-  if (cfg->seed > 0) {
-    fprintf(output, " seed=%llu", (unsigned long long)cfg->seed);
-  } else {
-    fprintf(output, " seed=default");
-  }
+  sr_optimizer_log_int(output, "max_evals", cfg->max_evals);
+  sr_optimizer_log_int(output, "max_iters", cfg->max_iters);
+  sr_optimizer_log_seed(output, "seed", cfg->seed);
 
   fprintf(output, "\n");
 }

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -202,9 +202,6 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
   if (cfg->max_iters > 0) {
     sr_powell_iter_limit = cfg->max_iters;
     sr_sa_iter_limit = cfg->max_iters;
-    if (cfg->max_evals <= 0) {
-      sr_amoeba_eval_limit = cfg->max_iters;
-    }
   }
   if (cfg->seed > 0) {
     sa_idum = cfg->seed;

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -28,6 +28,7 @@ typedef struct sr_optimizer_entry {
 static int sr_run_simplex(int ndim, real dpos, const char *bak_file,
                           const char *log_file)
 {
+  (void)dpos;
   SR_SX(ndim, dpos, bak_file, log_file);
   return 0;
 }
@@ -178,6 +179,7 @@ static int sr_optimizer_read_seed_env(const char *name, uint64_t *out_value)
 
   if (!raw || !out_value) return 0;
   parsed = strtoull(raw, &end, 10);
+  /* CSEARCH_SEED=0 means "use the default seed", so ignore it here. */
   if (end == raw || parsed == 0) return 0;
   *out_value = (uint64_t)parsed;
   return 1;

--- a/src/search/sr_powell.c
+++ b/src/search/sr_powell.c
@@ -458,7 +458,8 @@ static int sr_powell_iteration(sr_powell_run_ctx *ctx)
 
 static int sr_powell_run(sr_powell_run_ctx *ctx, int *iter)
 {
-  for (*iter = 1; *iter <= MAX_ITER_POWELL; (*iter)++) {
+  const int limit = sr_powell_iter_limit > 0 ? sr_powell_iter_limit : MAX_ITER_POWELL;
+  for (*iter = 1; *iter <= limit; (*iter)++) {
     int rc = sr_powell_iteration(ctx);
     if (rc == 0) continue;
     return (rc == 1) ? 0 : rc;

--- a/src/search/srhelp.c
+++ b/src/search/srhelp.c
@@ -12,6 +12,7 @@ Changes:
 
 *********************************************************************/
 
+#include "search_optimizer.h"
 #include "search_ver.h"
 
 void search_usage(FILE *output) {
@@ -26,12 +27,11 @@ void search_usage(FILE *output) {
     fprintf(output, "  -d <delta>            : initial displacement\n");
     fprintf(output, "  -h --help             : print help and exit\n");
 	fprintf(output, "  -i <inp_file>         : surface parameter input file\n");
-	fprintf(output, "  -s <search_type>      : can be \n"
-                    "                          'ga' = genetic algorithm\n"
-                    "                          'sa' = simulated annealing\n"
-                    "                          'si' = simplex method (default)\n"
-                    "                          'sx' = simplex - duplicate\n"
-                    "                          'po' = simulated annealing\n");
+    fprintf(output, "  -s <search_type>      : can be \n");
+    sr_optimizer_print_help(output);
+    fprintf(output, "  --max-evals <n>       : limit objective evaluations (simplex).\n");
+    fprintf(output, "  --max-iters <n>       : limit iterations (Powell/annealing).\n");
+    fprintf(output, "  --seed <n>            : seed stochastic optimizers (annealing).\n");
     fprintf(output, "  -v <vertex_file>      : file to read vertex information if resuming search\n");                
     fprintf(output, "  -V --version          : print version and information about this program\n");
     fprintf(output, "\n");

--- a/src/search/srhelp.c
+++ b/src/search/srhelp.c
@@ -31,7 +31,7 @@ void search_usage(FILE *output) {
     sr_optimizer_print_help(output);
     fprintf(output, "  --max-evals <n>       : limit objective evaluations (simplex).\n");
     fprintf(output, "  --max-iters <n>       : limit iterations (Powell/annealing).\n");
-    fprintf(output, "  --seed <n>            : seed stochastic optimizers (annealing).\n");
+    fprintf(output, "  --seed <n>            : seed stochastic optimizers (annealing, 0=default).\n");
     fprintf(output, "  -v <vertex_file>      : file to read vertex information if resuming search\n");                
     fprintf(output, "  -V --version          : print version and information about this program\n");
     fprintf(output, "\n");

--- a/src/search/srsa.c
+++ b/src/search/srsa.c
@@ -33,7 +33,9 @@ GH/29.12.95 - insert dpos in parameter list: initial displacement
 #define START_TEMP     3.5
 #define EPSILON        0.25
 #define ALPHA          4
+#ifndef MAX_ITER_SA
 #define MAX_ITER_SA  200
+#endif
 #define ITER_SA      100
 
 /**********************************************************************/
@@ -87,7 +89,7 @@ static int sr_sa_run_temperature_loop(sr_simplex_buffers *b, int ndim, real *out
 #ifdef CONTROL
     fprintf(STDCTR, "(sr_sa): temperature = %.4f\n", temp);
 #endif
-    int budget = MAX_ITER_SA;
+    int budget = sr_sa_iter_limit > 0 ? sr_sa_iter_limit : MAX_ITER_SA;
     sr_amebsa_cfg cfg;
     cfg.ftol = temp;
     cfg.funk = sr_evalrf;

--- a/src/search/srsa.c
+++ b/src/search/srsa.c
@@ -26,6 +26,8 @@ GH/29.12.95 - insert dpos in parameter list: initial displacement
 #include <stdlib.h>
 // cppcheck-suppress missingIncludeSystem
 #include <string.h>
+// cppcheck-suppress missingIncludeSystem
+#include <stdint.h>
 
 #include "search.h"
 #include "sr_simplex.h"
@@ -40,7 +42,7 @@ GH/29.12.95 - insert dpos in parameter list: initial displacement
 
 /**********************************************************************/
 
-long sa_idum = -1;                /* seed for random number generator */
+uint64_t sa_idum = 0;             /* seed for random number generator */
 
 static FILE *sr_sa_open_log_append(const char *log_file)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,18 @@ else()
 endif()
 add_test(NAME search.parse COMMAND test_search_parse)
 
+add_executable(test_search_optimizer
+    test_search_optimizer.c
+    $<TARGET_OBJECTS:cleed_test_support>
+)
+target_include_directories(test_search_optimizer PRIVATE ${CLEED_TEST_INCLUDE_DIRS})
+if (WIN32)
+    target_link_libraries(test_search_optimizer PRIVATE searchStatic m)
+else()
+    target_link_libraries(test_search_optimizer PRIVATE search m)
+endif()
+add_test(NAME search.optimizer COMMAND test_search_optimizer)
+
 add_executable(test_search_vertex_stats
     test_search_vertex_stats.c
     $<TARGET_OBJECTS:cleed_test_support>

--- a/tests/test_search_amebsa.c
+++ b/tests/test_search_amebsa.c
@@ -9,7 +9,10 @@
 
 #include "test_support.h"
 
-extern long sa_idum;
+// cppcheck-suppress missingIncludeSystem
+#include <stdint.h>
+
+extern uint64_t sa_idum;
 
 static real quadratic_2d(real *x)
 {
@@ -40,7 +43,7 @@ typedef struct amebsa_result {
     int used;
 } amebsa_result;
 
-static int run_amebsa_once(real temptr, long seed, amebsa_result *out)
+static int run_amebsa_once(real temptr, uint64_t seed, amebsa_result *out)
 {
     const int ndim = 2;
     const int mpts = ndim + 1;
@@ -108,8 +111,8 @@ static int run_amebsa_once(real temptr, long seed, amebsa_result *out)
 static int test_reproducible_with_fixed_seed(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once((real)1.0, -12345, &r1) != 0) return 1;
-    if (run_amebsa_once((real)1.0, -12345, &r2) != 0) return 1;
+    if (run_amebsa_once((real)1.0, 12345U, &r1) != 0) return 1;
+    if (run_amebsa_once((real)1.0, 12345U, &r2) != 0) return 1;
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);
@@ -122,8 +125,8 @@ static int test_reproducible_with_fixed_seed(void)
 static int test_zero_temperature_seed_independent(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once((real)0.0, -1, &r1) != 0) return 1;
-    if (run_amebsa_once((real)0.0, -999, &r2) != 0) return 1;
+    if (run_amebsa_once((real)0.0, 1U, &r1) != 0) return 1;
+    if (run_amebsa_once((real)0.0, 999U, &r2) != 0) return 1;
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);

--- a/tests/test_search_amebsa.c
+++ b/tests/test_search_amebsa.c
@@ -111,8 +111,12 @@ static int run_amebsa_once(real temptr, uint64_t seed, amebsa_result *out)
 static int test_reproducible_with_fixed_seed(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once(1.0, 12345U, &r1) != 0) return 1;
-    if (run_amebsa_once(1.0, 12345U, &r2) != 0) return 1;
+    if (run_amebsa_once(1.0, UINT64_C(12345), &r1) != 0) {
+        return 1;
+    }
+    if (run_amebsa_once(1.0, UINT64_C(12345), &r2) != 0) {
+        return 1;
+    }
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);
@@ -125,8 +129,12 @@ static int test_reproducible_with_fixed_seed(void)
 static int test_zero_temperature_seed_independent(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once(0.0, 1U, &r1) != 0) return 1;
-    if (run_amebsa_once(0.0, 999U, &r2) != 0) return 1;
+    if (run_amebsa_once(0.0, UINT64_C(1), &r1) != 0) {
+        return 1;
+    }
+    if (run_amebsa_once(0.0, UINT64_C(999), &r2) != 0) {
+        return 1;
+    }
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);

--- a/tests/test_search_amebsa.c
+++ b/tests/test_search_amebsa.c
@@ -111,8 +111,8 @@ static int run_amebsa_once(real temptr, uint64_t seed, amebsa_result *out)
 static int test_reproducible_with_fixed_seed(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once((real)1.0, 12345U, &r1) != 0) return 1;
-    if (run_amebsa_once((real)1.0, 12345U, &r2) != 0) return 1;
+    if (run_amebsa_once(1.0, 12345U, &r1) != 0) return 1;
+    if (run_amebsa_once(1.0, 12345U, &r2) != 0) return 1;
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);
@@ -125,8 +125,8 @@ static int test_reproducible_with_fixed_seed(void)
 static int test_zero_temperature_seed_independent(void)
 {
     amebsa_result r1, r2;
-    if (run_amebsa_once((real)0.0, 1U, &r1) != 0) return 1;
-    if (run_amebsa_once((real)0.0, 999U, &r2) != 0) return 1;
+    if (run_amebsa_once(0.0, 1U, &r1) != 0) return 1;
+    if (run_amebsa_once(0.0, 999U, &r2) != 0) return 1;
 
     CLEED_TEST_ASSERT_NEAR(r1.yb, r2.yb, AMEBSA_DETERMINISM_TOL);
     CLEED_TEST_ASSERT_NEAR(r1.pb1, r2.pb1, AMEBSA_DETERMINISM_TOL);

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -1,0 +1,71 @@
+#include "search_optimizer.h"
+#include "search.h"
+#include "test_support.h"
+
+// cppcheck-suppress missingIncludeSystem
+#include <stdlib.h>
+// cppcheck-suppress missingIncludeSystem
+#include <string.h>
+
+static int test_lookup_by_name(void)
+{
+    const sr_optimizer_def *opt = NULL;
+
+    opt = sr_optimizer_by_name("si");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_SIMPLEX);
+
+    opt = sr_optimizer_by_name("simplex");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_SIMPLEX);
+
+    opt = sr_optimizer_by_name("po");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_POWELL);
+
+    opt = sr_optimizer_by_name("sa");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_SIM_ANNEALING);
+
+    opt = sr_optimizer_by_name("ga");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_GENETIC);
+
+    opt = sr_optimizer_by_name("unknown");
+    CLEED_TEST_ASSERT(opt == NULL);
+
+    return 0;
+}
+
+static int test_config_from_env(void)
+{
+    sr_optimizer_config cfg;
+    sr_optimizer_config_init(&cfg);
+
+    setenv("CSEARCH_MAX_EVALS", "123", 1);
+    setenv("CSEARCH_MAX_ITERS", "456", 1);
+    setenv("CSEARCH_SEED", "789", 1);
+
+    sr_optimizer_config_from_env(&cfg);
+
+    CLEED_TEST_ASSERT(cfg.max_evals == 123);
+    CLEED_TEST_ASSERT(cfg.max_iters == 456);
+    CLEED_TEST_ASSERT(cfg.seed == 789);
+
+    unsetenv("CSEARCH_MAX_EVALS");
+    unsetenv("CSEARCH_MAX_ITERS");
+    unsetenv("CSEARCH_SEED");
+
+    return 0;
+}
+
+int main(void)
+{
+    if (test_lookup_by_name() != 0) {
+        return 1;
+    }
+    if (test_config_from_env() != 0) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -7,6 +7,24 @@
 // cppcheck-suppress missingIncludeSystem
 #include <string.h>
 
+static int test_set_env_value(const char *name, const char *value)
+{
+#ifdef _WIN32
+    return _putenv_s(name, value);
+#else
+    return setenv(name, value, 1);
+#endif
+}
+
+static int test_unset_env_value(const char *name)
+{
+#ifdef _WIN32
+    return _putenv_s(name, "");
+#else
+    return unsetenv(name);
+#endif
+}
+
 static int test_lookup_by_name(void)
 {
     const sr_optimizer_def *opt = NULL;
@@ -42,9 +60,9 @@ static int test_config_from_env(void)
     sr_optimizer_config cfg;
     sr_optimizer_config_init(&cfg);
 
-    setenv("CSEARCH_MAX_EVALS", "123", 1);
-    setenv("CSEARCH_MAX_ITERS", "456", 1);
-    setenv("CSEARCH_SEED", "789", 1);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "123") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "456") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "789") == 0);
 
     sr_optimizer_config_from_env(&cfg);
 
@@ -52,9 +70,9 @@ static int test_config_from_env(void)
     CLEED_TEST_ASSERT(cfg.max_iters == 456);
     CLEED_TEST_ASSERT(cfg.seed == 789);
 
-    unsetenv("CSEARCH_MAX_EVALS");
-    unsetenv("CSEARCH_MAX_ITERS");
-    unsetenv("CSEARCH_SEED");
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
 
     return 0;
 }

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -79,6 +79,65 @@ static int test_config_from_env(void)
     return 0;
 }
 
+static int test_config_from_env_invalid_values(void)
+{
+    sr_optimizer_config cfg;
+    sr_optimizer_config_init(&cfg);
+
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "nope") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "n/a") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "oops") == 0);
+
+    sr_optimizer_config_from_env(&cfg);
+
+    CLEED_TEST_ASSERT(cfg.max_evals == 0);
+    CLEED_TEST_ASSERT(cfg.max_iters == 0);
+    CLEED_TEST_ASSERT(cfg.seed == 0);
+
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+
+    return 0;
+}
+
+static int test_config_from_env_edge_values(void)
+{
+    sr_optimizer_config cfg;
+    sr_optimizer_config_init(&cfg);
+
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "-5") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "-10") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "0") == 0);
+
+    sr_optimizer_config_from_env(&cfg);
+
+    CLEED_TEST_ASSERT(cfg.max_evals == 0);
+    CLEED_TEST_ASSERT(cfg.max_iters == 0);
+    CLEED_TEST_ASSERT(cfg.seed == 0);
+
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+
+    sr_optimizer_config_init(&cfg);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "9999999999") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "9999999999") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "18446744073709551615") == 0);
+
+    sr_optimizer_config_from_env(&cfg);
+
+    CLEED_TEST_ASSERT(cfg.max_evals == 0);
+    CLEED_TEST_ASSERT(cfg.max_iters == 0);
+    CLEED_TEST_ASSERT(cfg.seed == UINT64_MAX);
+
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+
+    return 0;
+}
+
 static int test_config_apply(void)
 {
     const int orig_amoeba = sr_amoeba_eval_limit;
@@ -86,11 +145,6 @@ static int test_config_apply(void)
     const int orig_sa = sr_sa_iter_limit;
     const uint64_t orig_seed = sa_idum;
     sr_optimizer_config cfg;
-
-    sr_amoeba_eval_limit = orig_amoeba;
-    sr_powell_iter_limit = orig_powell;
-    sr_sa_iter_limit = orig_sa;
-    sa_idum = orig_seed;
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_evals = 1234;
@@ -155,6 +209,12 @@ int main(void)
         return 1;
     }
     if (test_config_from_env() != 0) {
+        return 1;
+    }
+    if (test_config_from_env_invalid_values() != 0) {
+        return 1;
+    }
+    if (test_config_from_env_edge_values() != 0) {
         return 1;
     }
     if (test_config_apply() != 0) {

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -27,34 +27,41 @@ static int test_unset_env_value(const char *name)
 #endif
 }
 
-static void test_set_env_triplet(const char *evals, const char *iters, const char *seed)
+static int test_set_env_triplet(const char *evals, const char *iters, const char *seed)
 {
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", evals) == 0);
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", iters) == 0);
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", seed) == 0);
+    return 0;
 }
 
-static void test_unset_env_triplet(void)
+static int test_unset_env_triplet(void)
 {
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+    return 0;
 }
 
-static void test_assert_env_config(const char *evals, const char *iters, const char *seed,
-                                   int expected_evals, int expected_iters, uint64_t expected_seed)
+static int test_assert_env_config(const char *evals, const char *iters, const char *seed,
+                                  int expected_evals, int expected_iters, uint64_t expected_seed)
 {
     sr_optimizer_config cfg;
     sr_optimizer_config_init(&cfg);
 
-    test_set_env_triplet(evals, iters, seed);
+    if (test_set_env_triplet(evals, iters, seed) != 0) {
+        return 1;
+    }
     sr_optimizer_config_from_env(&cfg);
 
     CLEED_TEST_ASSERT(cfg.max_evals == expected_evals);
     CLEED_TEST_ASSERT(cfg.max_iters == expected_iters);
     CLEED_TEST_ASSERT(cfg.seed == expected_seed);
 
-    test_unset_env_triplet();
+    if (test_unset_env_triplet() != 0) {
+        return 1;
+    }
+    return 0;
 }
 
 static void test_restore_globals(int amoeba, int powell, int sa, uint64_t seed)
@@ -97,23 +104,31 @@ static int test_lookup_by_name(void)
 
 static int test_config_from_env(void)
 {
-    test_assert_env_config("123", "456", "789", 123, 456, 789);
+    if (test_assert_env_config("123", "456", "789", 123, 456, 789) != 0) {
+        return 1;
+    }
 
     return 0;
 }
 
 static int test_config_from_env_invalid_values(void)
 {
-    test_assert_env_config("nope", "n/a", "oops", 0, 0, 0);
+    if (test_assert_env_config("nope", "n/a", "oops", 0, 0, 0) != 0) {
+        return 1;
+    }
 
     return 0;
 }
 
 static int test_config_from_env_edge_values(void)
 {
-    test_assert_env_config("-5", "-10", "0", 0, 0, 0);
-    test_assert_env_config("9999999999", "9999999999", "18446744073709551615",
-                           0, 0, UINT64_MAX);
+    if (test_assert_env_config("-5", "-10", "0", 0, 0, 0) != 0) {
+        return 1;
+    }
+    if (test_assert_env_config("9999999999", "9999999999", "18446744073709551615",
+                               0, 0, UINT64_MAX) != 0) {
+        return 1;
+    }
 
     return 0;
 }

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -3,6 +3,8 @@
 #include "test_support.h"
 
 // cppcheck-suppress missingIncludeSystem
+#include <inttypes.h>
+// cppcheck-suppress missingIncludeSystem
 #include <stdlib.h>
 // cppcheck-suppress missingIncludeSystem
 #include <string.h>
@@ -77,12 +79,85 @@ static int test_config_from_env(void)
     return 0;
 }
 
+static int test_config_apply(void)
+{
+    const int orig_amoeba = sr_amoeba_eval_limit;
+    const int orig_powell = sr_powell_iter_limit;
+    const int orig_sa = sr_sa_iter_limit;
+    const uint64_t orig_seed = sa_idum;
+    sr_optimizer_config cfg;
+
+    sr_amoeba_eval_limit = orig_amoeba;
+    sr_powell_iter_limit = orig_powell;
+    sr_sa_iter_limit = orig_sa;
+    sa_idum = orig_seed;
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.max_evals = 1234;
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == 1234);
+    CLEED_TEST_ASSERT(sr_powell_iter_limit == orig_powell);
+    CLEED_TEST_ASSERT(sr_sa_iter_limit == orig_sa);
+    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+
+    sr_amoeba_eval_limit = orig_amoeba;
+    sr_powell_iter_limit = orig_powell;
+    sr_sa_iter_limit = orig_sa;
+    sa_idum = orig_seed;
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.max_iters = 456;
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sr_powell_iter_limit == 456);
+    CLEED_TEST_ASSERT(sr_sa_iter_limit == 456);
+    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == orig_amoeba);
+    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+
+    sr_amoeba_eval_limit = orig_amoeba;
+    sr_powell_iter_limit = orig_powell;
+    sr_sa_iter_limit = orig_sa;
+    sa_idum = orig_seed;
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.max_evals = 789;
+    cfg.max_iters = 321;
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == 789);
+    CLEED_TEST_ASSERT(sr_powell_iter_limit == 321);
+    CLEED_TEST_ASSERT(sr_sa_iter_limit == 321);
+    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+
+    sr_amoeba_eval_limit = orig_amoeba;
+    sr_powell_iter_limit = orig_powell;
+    sr_sa_iter_limit = orig_sa;
+    sa_idum = orig_seed;
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.seed = UINT64_C(0x123456789);
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sa_idum == cfg.seed);
+
+    sr_amoeba_eval_limit = orig_amoeba;
+    sr_powell_iter_limit = orig_powell;
+    sr_sa_iter_limit = orig_sa;
+    sa_idum = orig_seed;
+
+    return 0;
+}
+
 int main(void)
 {
     if (test_lookup_by_name() != 0) {
         return 1;
     }
     if (test_config_from_env() != 0) {
+        return 1;
+    }
+    if (test_config_apply() != 0) {
         return 1;
     }
     return 0;

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -120,33 +120,48 @@ static int test_config_from_env_edge_values(void)
 
 static int test_config_apply(void)
 {
+    const int default_amoeba = MAX_ITER_AMOEBA;
+    const int default_powell = MAX_ITER_POWELL;
+    const int default_sa = MAX_ITER_SA;
     const int orig_amoeba = sr_amoeba_eval_limit;
     const int orig_powell = sr_powell_iter_limit;
     const int orig_sa = sr_sa_iter_limit;
     const uint64_t orig_seed = sa_idum;
     sr_optimizer_config cfg;
 
+    test_restore_globals(1, 2, 3, UINT64_C(55));
+    memset(&cfg, 0, sizeof(cfg));
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == default_amoeba);
+    CLEED_TEST_ASSERT(sr_powell_iter_limit == default_powell);
+    CLEED_TEST_ASSERT(sr_sa_iter_limit == default_sa);
+    CLEED_TEST_ASSERT(sa_idum == 0);
+
+    test_restore_globals(1, 2, 3, UINT64_C(55));
+
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_evals = 1234;
+    cfg.max_iters = 456;
     sr_optimizer_config_apply(&cfg);
 
     CLEED_TEST_ASSERT(sr_amoeba_eval_limit == 1234);
-    CLEED_TEST_ASSERT(sr_powell_iter_limit == orig_powell);
-    CLEED_TEST_ASSERT(sr_sa_iter_limit == orig_sa);
-    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+    CLEED_TEST_ASSERT(sr_powell_iter_limit == 456);
+    CLEED_TEST_ASSERT(sr_sa_iter_limit == 456);
+    CLEED_TEST_ASSERT(sa_idum == 0);
 
-    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
+    test_restore_globals(1, 2, 3, UINT64_C(55));
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_iters = 456;
     sr_optimizer_config_apply(&cfg);
 
+    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == default_amoeba);
     CLEED_TEST_ASSERT(sr_powell_iter_limit == 456);
     CLEED_TEST_ASSERT(sr_sa_iter_limit == 456);
-    CLEED_TEST_ASSERT(sr_amoeba_eval_limit == orig_amoeba);
-    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+    CLEED_TEST_ASSERT(sa_idum == 0);
 
-    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
+    test_restore_globals(1, 2, 3, UINT64_C(55));
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_evals = 789;
@@ -156,9 +171,9 @@ static int test_config_apply(void)
     CLEED_TEST_ASSERT(sr_amoeba_eval_limit == 789);
     CLEED_TEST_ASSERT(sr_powell_iter_limit == 321);
     CLEED_TEST_ASSERT(sr_sa_iter_limit == 321);
-    CLEED_TEST_ASSERT(sa_idum == orig_seed);
+    CLEED_TEST_ASSERT(sa_idum == 0);
 
-    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
+    test_restore_globals(1, 2, 3, UINT64_C(55));
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.seed = UINT64_C(0x123456789);

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -27,6 +27,44 @@ static int test_unset_env_value(const char *name)
 #endif
 }
 
+static void test_set_env_triplet(const char *evals, const char *iters, const char *seed)
+{
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", evals) == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", iters) == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", seed) == 0);
+}
+
+static void test_unset_env_triplet(void)
+{
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+}
+
+static void test_assert_env_config(const char *evals, const char *iters, const char *seed,
+                                   int expected_evals, int expected_iters, uint64_t expected_seed)
+{
+    sr_optimizer_config cfg;
+    sr_optimizer_config_init(&cfg);
+
+    test_set_env_triplet(evals, iters, seed);
+    sr_optimizer_config_from_env(&cfg);
+
+    CLEED_TEST_ASSERT(cfg.max_evals == expected_evals);
+    CLEED_TEST_ASSERT(cfg.max_iters == expected_iters);
+    CLEED_TEST_ASSERT(cfg.seed == expected_seed);
+
+    test_unset_env_triplet();
+}
+
+static void test_restore_globals(int amoeba, int powell, int sa, uint64_t seed)
+{
+    sr_amoeba_eval_limit = amoeba;
+    sr_powell_iter_limit = powell;
+    sr_sa_iter_limit = sa;
+    sa_idum = seed;
+}
+
 static int test_lookup_by_name(void)
 {
     const sr_optimizer_def *opt = NULL;
@@ -59,81 +97,23 @@ static int test_lookup_by_name(void)
 
 static int test_config_from_env(void)
 {
-    sr_optimizer_config cfg;
-    sr_optimizer_config_init(&cfg);
-
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "123") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "456") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "789") == 0);
-
-    sr_optimizer_config_from_env(&cfg);
-
-    CLEED_TEST_ASSERT(cfg.max_evals == 123);
-    CLEED_TEST_ASSERT(cfg.max_iters == 456);
-    CLEED_TEST_ASSERT(cfg.seed == 789);
-
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+    test_assert_env_config("123", "456", "789", 123, 456, 789);
 
     return 0;
 }
 
 static int test_config_from_env_invalid_values(void)
 {
-    sr_optimizer_config cfg;
-    sr_optimizer_config_init(&cfg);
-
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "nope") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "n/a") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "oops") == 0);
-
-    sr_optimizer_config_from_env(&cfg);
-
-    CLEED_TEST_ASSERT(cfg.max_evals == 0);
-    CLEED_TEST_ASSERT(cfg.max_iters == 0);
-    CLEED_TEST_ASSERT(cfg.seed == 0);
-
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+    test_assert_env_config("nope", "n/a", "oops", 0, 0, 0);
 
     return 0;
 }
 
 static int test_config_from_env_edge_values(void)
 {
-    sr_optimizer_config cfg;
-    sr_optimizer_config_init(&cfg);
-
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "-5") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "-10") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "0") == 0);
-
-    sr_optimizer_config_from_env(&cfg);
-
-    CLEED_TEST_ASSERT(cfg.max_evals == 0);
-    CLEED_TEST_ASSERT(cfg.max_iters == 0);
-    CLEED_TEST_ASSERT(cfg.seed == 0);
-
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
-
-    sr_optimizer_config_init(&cfg);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_EVALS", "9999999999") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_MAX_ITERS", "9999999999") == 0);
-    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_SEED", "18446744073709551615") == 0);
-
-    sr_optimizer_config_from_env(&cfg);
-
-    CLEED_TEST_ASSERT(cfg.max_evals == 0);
-    CLEED_TEST_ASSERT(cfg.max_iters == 0);
-    CLEED_TEST_ASSERT(cfg.seed == UINT64_MAX);
-
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
-    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_SEED") == 0);
+    test_assert_env_config("-5", "-10", "0", 0, 0, 0);
+    test_assert_env_config("9999999999", "9999999999", "18446744073709551615",
+                           0, 0, UINT64_MAX);
 
     return 0;
 }
@@ -155,10 +135,7 @@ static int test_config_apply(void)
     CLEED_TEST_ASSERT(sr_sa_iter_limit == orig_sa);
     CLEED_TEST_ASSERT(sa_idum == orig_seed);
 
-    sr_amoeba_eval_limit = orig_amoeba;
-    sr_powell_iter_limit = orig_powell;
-    sr_sa_iter_limit = orig_sa;
-    sa_idum = orig_seed;
+    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_iters = 456;
@@ -169,10 +146,7 @@ static int test_config_apply(void)
     CLEED_TEST_ASSERT(sr_amoeba_eval_limit == orig_amoeba);
     CLEED_TEST_ASSERT(sa_idum == orig_seed);
 
-    sr_amoeba_eval_limit = orig_amoeba;
-    sr_powell_iter_limit = orig_powell;
-    sr_sa_iter_limit = orig_sa;
-    sa_idum = orig_seed;
+    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.max_evals = 789;
@@ -184,10 +158,7 @@ static int test_config_apply(void)
     CLEED_TEST_ASSERT(sr_sa_iter_limit == 321);
     CLEED_TEST_ASSERT(sa_idum == orig_seed);
 
-    sr_amoeba_eval_limit = orig_amoeba;
-    sr_powell_iter_limit = orig_powell;
-    sr_sa_iter_limit = orig_sa;
-    sa_idum = orig_seed;
+    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.seed = UINT64_C(0x123456789);
@@ -195,10 +166,7 @@ static int test_config_apply(void)
 
     CLEED_TEST_ASSERT(sa_idum == cfg.seed);
 
-    sr_amoeba_eval_limit = orig_amoeba;
-    sr_powell_iter_limit = orig_powell;
-    sr_sa_iter_limit = orig_sa;
-    sa_idum = orig_seed;
+    test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Introduces a stable optimizer interface and registry for `csearch`, enabling consistent configuration of iteration limits, evaluation budgets, and deterministic seeds. This foundational PR enables future optimizer additions (PSO, DE) with minimal integration effort.

## Problem

| Issue | Impact |
|-------|--------|
| No unified optimizer interface | Each optimizer requires custom integration code |
| No runtime configuration for limits/seeds | Reproducible runs require code changes |
| Inconsistent optimizer selection | Hard-coded switch statements are fragile |

## Solution

### Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                        csearch CLI                          │
│  --search <type>  --max-iters N  --max-evals M  --seed S   │
└────────────────────────────┬────────────────────────────────┘
                             │
                             ▼
┌─────────────────────────────────────────────────────────────┐
│                  sr_optimizer_registry                       │
│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐         │
│  │   simplex   │  │   powell    │  │  annealing  │   ...   │
│  │  (si, sx)   │  │    (po)     │  │  (sa)       │         │
│  └─────────────┘  └─────────────┘  └─────────────┘         │
└────────────────────────────┬────────────────────────────────┘
                             │
                             ▼
┌─────────────────────────────────────────────────────────────┐
│                  sr_optimizer_config                         │
│  max_evals │ max_iters │ seed → applies to global limits    │
└─────────────────────────────────────────────────────────────┘
```

### New CLI Options

| Option | Environment Variable | Description |
|--------|---------------------|-------------|
| `--max-evals N` | `CSEARCH_MAX_EVALS` | Maximum function evaluations |
| `--max-iters N` | `CSEARCH_MAX_ITERS` | Maximum optimizer iterations |
| `--seed S` | `CSEARCH_SEED` | Deterministic seed for RNG |

### Optimizer Types

| Type | Primary | Aliases | Status |
|------|---------|---------|--------|
| Simplex | `si` | `sx`, `simplex` | Implemented (default) |
| Powell | `po` | `powell` | Implemented |
| Simulated Annealing | `sa` | `anneal`, `annealing` | Implemented |
| Genetic Algorithm | `ga` | `genetic` | Stub only |

### Key Files Changed

| File | Purpose |
|------|---------|
| [`sr_optimizers.c`](https://github.com/Liam-Deacon/CLEED/blob/e634fef/src/search/sr_optimizers.c) | Optimizer registry and config API |
| [`search_optimizer.h`](https://github.com/Liam-Deacon/CLEED/blob/e634fef/src/include/search_optimizer.h) | Public header with types and functions |
| [`csearch.c`](https://github.com/Liam-Deacon/CLEED/blob/e634fef/src/search/csearch.c) | Updated to use registry |
| [`ran1.c`](https://github.com/Liam-Deacon/CLEED/blob/e634fef/src/search/ran1.c) | Fixed security hotspot (rand→xorshift64) |

## Testing

```bash
# Pre-commit checks
python3 -m pre_commit run --all-files

# Build and test
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel
ctest --test-dir build --output-on-failure
```

All 17 tests pass across Linux, macOS, and Windows.

## Security

- **Fixed**: Replaced insecure `rand()/srand()` in `ran1.c` with portable xorshift64* PRNG (Vigna 2016)
- The new `sr_rng` module provides deterministic, reproducible random numbers across platforms

## Follow-ups

- [ ] PR #66: Add PSO optimizer
- [ ] PR #67: Add Differential Evolution optimizer

## Summary by Sourcery

Introduce a centralized optimizer registry and configuration layer for csearch, adding configurable iteration/evaluation limits and deterministic seeding while updating the CLI, logging, and RNG to support reproducible, budgeted optimization runs.

New Features:
- Add a search optimizer registry and public optimizer interface to select algorithms by name or type and to centralize optimizer metadata.
- Introduce CLI and environment-variable configuration for max evaluations, max iterations, and RNG seed for csearch optimizers.
- Add logging of the selected optimizer and its runtime configuration to the csearch log output.

Bug Fixes:
- Replace use of rand()/srand() in ran1.c with a portable xorshift64*-based PRNG to address security and reproducibility issues.

Enhancements:
- Refactor csearch to dispatch optimizers through the new registry instead of a hard-coded switch statement, simplifying future optimizer additions.
- Wire global iteration and evaluation limits for simplex, Powell, and simulated annealing through configurable globals driven by the optimizer config.
- Improve CLI help and man page documentation for optimizer selection and new optimization limit options.

Build:
- Register the new sr_optimizers.c module in the search library build system across CMake and Makefile builds.

Tests:
- Add unit tests for optimizer lookup by name and configuration loading from environment variables.
- Extend the test CMake configuration to build and run the new optimizer tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New optimizer choices: simplex (default), Powell, simulated annealing, plus a placeholder genetic option.
  * CLI options to control searches: --max-evals, --max-iters, --seed.

* **Behavior**
  * Search methods honor configurable evaluation/iteration limits.
  * Portable deterministic RNG; non-zero seeds reproduce runs across platforms; 0 uses the built-in default.

* **Documentation**
  * Updated docs and man page; new env vars: CSEARCH_MAX_EVALS, CSEARCH_MAX_ITERS, CSEARCH_SEED.

* **Tests**
  * Added tests for optimizer selection and env-based configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->