### PR TITLE
feat(search): add differential evolution optimizer

### DIFF
--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -124,6 +124,11 @@ The implementation uses defaults tuned for LEED optimisation:
   *Journal of Global Optimization*, 11, 341–359.
   `doi:10.1023/A:1008202821328 <https://doi.org/10.1023/A:1008202821328>`_
 
+- Storn, R., & Price, K. (1995). Differential Evolution—A Simple and
+  Efficient Adaptive Scheme for Global Optimization over Continuous
+  Spaces. International Computer Science Institute, Berkeley, CA,
+  Technical Report TR-95-012.
+
 .. _csearch_syntax:
 
 Syntax

--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -102,19 +102,20 @@ Options
   - :code:`po`: Powell.
   - :code:`sa`: simulated annealing.
   - :code:`ps`: particle swarm optimisation.
+  - :code:`de`: differential evolution.
   - :code:`ga`: genetic algorithm (not implemented).
 
 :code:`--max-evals <n>`
 
-  Limits objective evaluations (simplex/PSO). Overrides the default iteration budget.
+  Limits objective evaluations (simplex/PSO/DE). Overrides the default iteration budget.
 
 :code:`--max-iters <n>`
 
-  Limits iterations (Powell/annealing/PSO). Overrides the default iteration budget.
+  Limits iterations (Powell/annealing/PSO/DE). Overrides the default iteration budget.
 
 :code:`--seed <n>`
 
-  Sets a deterministic seed for stochastic optimizers (simulated annealing/PSO).
+  Sets a deterministic seed for stochastic optimizers (simulated annealing/PSO/DE).
 
 .. note::
    Seeds are parsed as unsigned 64-bit integers. A value of 0 selects the
@@ -165,13 +166,13 @@ Environment
   if the parent directory of this program is in the system :envvar:`PATH` variable.
 
 :envvar:`CSEARCH_MAX_EVALS`
-  Optional evaluation budget for simplex/PSO searches (same as :code:`--max-evals`).
+  Optional evaluation budget for simplex/PSO/DE searches (same as :code:`--max-evals`).
 
 :envvar:`CSEARCH_MAX_ITERS`
-  Optional iteration budget for Powell/annealing/PSO searches (same as :code:`--max-iters`).
+  Optional iteration budget for Powell/annealing/PSO/DE searches (same as :code:`--max-iters`).
 
 :envvar:`CSEARCH_SEED`
-  Optional deterministic seed for simulated annealing/PSO (same as :code:`--seed`).
+  Optional deterministic seed for simulated annealing/PSO/DE (same as :code:`--seed`).
 
   A value of 0 uses the built-in default seed for the deterministic annealing
   RNG. Non-zero values are parsed as unsigned 64-bit integers.

--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -142,6 +142,22 @@ Options
 
   Sets the PSO velocity clamp. Default: dpos (initial displacement). Recommended range: 0.1–5.0.
 
+:code:`--de-pop <n>`
+
+  Sets the DE population size.
+
+:code:`--de-weight <n>`
+
+  Sets the DE weight factor.
+
+:code:`--de-cr <n>`
+
+  Sets the DE crossover rate.
+
+:code:`--de-span <n>`
+
+  Sets the DE initial span.
+
 :code:`-v <vertex_file>`
                      
   Allows the search to be restarted with the current simplex, provided 
@@ -191,6 +207,18 @@ Environment
 
 :envvar:`CSEARCH_PSO_VMAX`
   Optional PSO velocity clamp (same as :code:`--pso-vmax`).
+
+:envvar:`CSEARCH_DE_POP`
+  Optional DE population size (same as :code:`--de-pop`).
+
+:envvar:`CSEARCH_DE_WEIGHT`
+  Optional DE weight factor (same as :code:`--de-weight`).
+
+:envvar:`CSEARCH_DE_CR`
+  Optional DE crossover rate (same as :code:`--de-cr`).
+
+:envvar:`CSEARCH_DE_SPAN`
+  Optional DE initial span (same as :code:`--de-span`).
 
 :envvar:`CLEED_PHASE`
   Directory path of the phase shift files used in  the  surface and bulk models. 

--- a/doc/LEED_programs/csearch.rst
+++ b/doc/LEED_programs/csearch.rst
@@ -69,6 +69,61 @@ tuned for LEED optimisation: :math:`\omega = 0.729`, :math:`c_1 = c_2 = 1.494`.
   *Proceedings of IEEE CEC 1998*, 69–73.
   `doi:10.1109/ICEC.1998.699146 <https://doi.org/10.1109/ICEC.1998.699146>`_
 
+.. _csearch_de:
+
+Differential Evolution (DE)
+---------------------------
+
+Differential Evolution is a population-based stochastic optimizer that
+evolves candidate solutions using vector differences. The implementation
+uses the classic DE/rand/1/bin variant.
+
+**Algorithm (Storn & Price, 1997)**
+
+For each target vector :math:`\mathbf{x}_i` in the population:
+
+1. **Mutation:** Generate a mutant vector by combining three randomly
+   selected distinct individuals :math:`a`, :math:`b`, :math:`c`:
+
+   .. math::
+
+      \mathbf{v}_i = \mathbf{x}_a + F (\mathbf{x}_b - \mathbf{x}_c)
+
+   where :math:`F \in (0, 2]` is the differential weight (scaling factor).
+
+2. **Crossover:** Create a trial vector :math:`\mathbf{u}_i` using binomial
+   crossover:
+
+   .. math::
+
+      u_{i,j} = \begin{cases}
+        v_{i,j} & \text{if } r_j < CR \text{ or } j = j_{\text{rand}} \\
+        x_{i,j} & \text{otherwise}
+      \end{cases}
+
+   where :math:`CR \in [0, 1]` is the crossover probability and
+   :math:`j_{\text{rand}}` ensures at least one component comes from the
+   mutant.
+
+3. **Selection:** Replace the target if the trial is at least as good:
+
+   .. math::
+
+      \mathbf{x}_i^{(t+1)} = \begin{cases}
+        \mathbf{u}_i & \text{if } f(\mathbf{u}_i) \le f(\mathbf{x}_i^{(t)}) \\
+        \mathbf{x}_i^{(t)} & \text{otherwise}
+      \end{cases}
+
+The implementation uses defaults tuned for LEED optimisation:
+:math:`F = 0.8`, :math:`CR = 0.9`, population size = 10×ndim (minimum 20).
+
+**References:**
+
+- Storn, R., & Price, K. (1997). Differential Evolution – A Simple and
+  Efficient Heuristic for Global Optimization over Continuous Spaces.
+  *Journal of Global Optimization*, 11, 341–359.
+  `doi:10.1023/A:1008202821328 <https://doi.org/10.1023/A:1008202821328>`_
+
 .. _csearch_syntax:
 
 Syntax
@@ -144,19 +199,19 @@ Options
 
 :code:`--de-pop <n>`
 
-  Sets the DE population size.
+  Sets the DE population size. Default: 10×ndim (minimum 20). Recommended range: 20–200.
 
 :code:`--de-weight <n>`
 
-  Sets the DE weight factor.
+  Sets the DE differential weight (scaling factor F). Default: 0.8. Recommended range: 0.4–1.0.
 
 :code:`--de-cr <n>`
 
-  Sets the DE crossover rate.
+  Sets the DE crossover probability. Default: 0.9. Recommended range: 0.5–1.0.
 
 :code:`--de-span <n>`
 
-  Sets the DE initial span.
+  Sets the DE initial search span for population initialization. Default: dpos (initial displacement). Recommended range: 0.5–5.0.
 
 :code:`-v <vertex_file>`
                      

--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -69,6 +69,22 @@ This page defines the environment variables referenced throughout the manual.
 
    Optional PSO velocity clamp (same as ``--pso-vmax``).
 
+.. envvar:: CSEARCH_DE_POP
+
+   Optional DE population size (same as ``--de-pop``).
+
+.. envvar:: CSEARCH_DE_WEIGHT
+
+   Optional DE mutation weight factor (same as ``--de-weight``).
+
+.. envvar:: CSEARCH_DE_CR
+
+   Optional DE crossover probability (same as ``--de-cr``).
+
+.. envvar:: CSEARCH_DE_SPAN
+
+   Optional DE initial parameter span (same as ``--de-span``).
+
 .. envvar:: RF_HELP_FILE
 
    Path to a help file shown when :ref:`crfac` is invoked with ``-h``.

--- a/man/csearch.1
+++ b/man/csearch.1
@@ -97,6 +97,26 @@ sets the PSO social coefficient.
 .RS
 sets the PSO velocity clamp.
 .RE
+.IP --de-pop
+.I <n>
+.RS
+sets the DE population size.
+.RE
+.IP --de-weight
+.I <n>
+.RS
+sets the DE weight factor.
+.RE
+.IP --de-cr
+.I <n>
+.RS
+sets the DE crossover rate.
+.RE
+.IP --de-span
+.I <n>
+.RS
+sets the DE initial span.
+.RE
 .IP -v
 .I <vertex_file> 
 .RS
@@ -131,6 +151,14 @@ CSEARCH_PSO_C1: optional PSO cognitive coefficient (same as --pso-c1).
 CSEARCH_PSO_C2: optional PSO social coefficient (same as --pso-c2).
 .PP
 CSEARCH_PSO_VMAX: optional PSO velocity clamp (same as --pso-vmax).
+.PP
+CSEARCH_DE_POP: optional DE population size (same as --de-pop).
+.PP
+CSEARCH_DE_WEIGHT: optional DE weight factor (same as --de-weight).
+.PP
+CSEARCH_DE_CR: optional DE crossover rate (same as --de-cr).
+.PP
+CSEARCH_DE_SPAN: optional DE initial span (same as --de-span).
 .PP
 CLEED_PHASE: directory path of the phase shift files used in the surface and bulk models. Please refer to 
 .I phsh(1) 

--- a/man/csearch.1
+++ b/man/csearch.1
@@ -54,21 +54,23 @@ specifies the search algorithm to be used for the structure optimisation. Possib
 'sx' : Simplex algorithm (alternative)
 .br
 'ps' : Particle swarm optimisation
+.br
+'de' : Differential evolution
 .RE
 .IP --max-evals
 .I <n>
 .RS
-limits objective evaluations (simplex/PSO). This overrides the default iteration budget.
+limits objective evaluations (simplex/PSO/DE). This overrides the default iteration budget.
 .RE
 .IP --max-iters
 .I <n>
 .RS
-limits iterations (Powell/annealing/PSO). This overrides the default iteration budget.
+limits iterations (Powell/annealing/PSO/DE). This overrides the default iteration budget.
 .RE
 .IP --seed
 .I <n>
 .RS
-sets a deterministic seed for stochastic optimizers (simulated annealing/PSO).
+sets a deterministic seed for stochastic optimizers (simulated annealing/PSO/DE).
 .RE
 .IP --pso-swarm
 .I <n>
@@ -114,11 +116,11 @@ CSEARCH_RFAC: path of the
 .I crfac
  program used for the R factor evaluation. This may simply be 'crfac' if the parent directory of this program is in the system PATH variable.
 .PP
-CSEARCH_MAX_EVALS: optional evaluation budget for simplex/PSO searches (same as --max-evals).
+CSEARCH_MAX_EVALS: optional evaluation budget for simplex/PSO/DE searches (same as --max-evals).
 .PP
-CSEARCH_MAX_ITERS: optional iteration budget for Powell/annealing/PSO searches (same as --max-iters).
+CSEARCH_MAX_ITERS: optional iteration budget for Powell/annealing/PSO/DE searches (same as --max-iters).
 .PP
-CSEARCH_SEED: optional deterministic seed for simulated annealing/PSO (same as --seed).
+CSEARCH_SEED: optional deterministic seed for simulated annealing/PSO/DE (same as --seed).
 .PP
 CSEARCH_PSO_SWARM: optional PSO swarm size (same as --pso-swarm).
 .PP

--- a/man/csearch.1
+++ b/man/csearch.1
@@ -27,6 +27,25 @@ csearch is a computer program written in C which performs structure optimisation
 .I crfac
 , in order to calculate an R factor value for the current parameter set.
 
+.SH DIFFERENTIAL EVOLUTION
+
+The DE/rand/1/bin variant uses mutation, binomial crossover, and selection. For
+each target vector x_i, mutation builds:
+.PP
+v_i = x_r1 + F (x_r2 - x_r3)
+.PP
+Binomial crossover forms the trial vector:
+.PP
+u_{i,j} = v_{i,j} if r_j < CR or j = j_rand, otherwise x_{i,j}
+.PP
+Selection replaces x_i if f(u_i) <= f(x_i).
+.PP
+References: Storn, R., Price, K. (1997). Differential Evolution - A Simple and
+Efficient Heuristic for Global Optimization over Continuous Spaces. Journal of
+Global Optimization 11, 341-359. DOI: 10.1023/A:1008202821328. Storn, R., Price,
+K. (1995). Differential Evolution - A Simple and Efficient Adaptive Scheme for
+Global Optimization over Continuous Spaces. ICSI Technical Report TR-95-012.
+
 .SH OPTIONS
 
 .IP -i

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -52,6 +52,8 @@ extern real sr_pso_inertia;
 extern real sr_pso_c1;
 extern real sr_pso_c2;
 extern real sr_pso_vmax;
+extern int sr_de_eval_limit;
+extern int sr_de_iter_limit;
 extern uint64_t sa_idum;
 
 /*********************************************************************

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -54,6 +54,10 @@ extern real sr_pso_c2;
 extern real sr_pso_vmax;
 extern int sr_de_eval_limit;
 extern int sr_de_iter_limit;
+extern int sr_de_population;
+extern real sr_de_weight;
+extern real sr_de_crossover;
+extern real sr_de_init_span;
 extern uint64_t sa_idum;
 
 /*********************************************************************

--- a/src/include/search_def.h
+++ b/src/include/search_def.h
@@ -112,12 +112,16 @@ struct search_str
 
     \def SR_PSO
     Search code for the particle swarm optimisation (ps) method.
+
+    \def SR_DIFFERENTIAL_EVOLUTION
+    Search code for the differential evolution (de) method.
 */
 #define SR_SIMPLEX        1     /* enumeration of search algorithm types */
 #define SR_POWELL         2
 #define SR_SIM_ANNEALING  3
 #define SR_GENETIC        4
 #define SR_PSO            5
+#define SR_DIFFERENTIAL_EVOLUTION 6
 
 /*!
     \def SR_SX
@@ -134,6 +138,9 @@ struct search_str
 
     \def SR_PS
     Entry into particle swarm optimisation search.
+
+    \def SR_DE
+    Entry into differential evolution search.
 */  
 #if defined(USE_GSL) || defined(_USE_GSL)
     /* set search functions to GNU Scientific Library */
@@ -142,6 +149,7 @@ struct search_str
     #define SR_PO    sr_po_gsl
     #define SR_GA    sr_ga_gsl
     #define SR_PS    sr_pso
+    #define SR_DE    sr_de
     #define SR_RDINP sr_rdinp
     #define I_PAR_0  0          /* start index for parameters */
 # else
@@ -151,6 +159,7 @@ struct search_str
     #define SR_PO    sr_po
     #define SR_GA    sr_ga    
     #define SR_PS    sr_pso
+    #define SR_DE    sr_de
     #define SR_RDINP sr_rdinp
     #define I_PAR_0  1          /* start index for parameters */
 #endif
@@ -187,6 +196,8 @@ struct search_str
 #define MAX_ITER_SA     200     /* max. iterations per temperature in sr_sa */
 #define MAX_ITER_PSO    200     /* max. number of iterations in sr_pso */
 #define MAX_EVAL_PSO    2000    /* max. number of evaluations in sr_pso */
+#define MAX_ITER_DE     200     /* max. number of iterations in sr_de */
+#define MAX_EVAL_DE     2000    /* max. number of evaluations in sr_de */
 
 #define MAX_ITER_POWELL 100     /* max. number of iterations in sr_powell */
 #define BRENT_TOLERANCE 2.0e-2  /* tolerance criterion in function brent 

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -179,19 +179,19 @@ int sr_pso_optimize(const sr_pso_cfg *cfg, int ndim, real (*func)(const real *),
  */
 typedef struct sr_de_cfg {
   // cppcheck-suppress unusedStructMember
-  int population;
+  int population; /**< Population size (default: 10*ndim, min: 20, range: >0) */
   // cppcheck-suppress unusedStructMember
-  int max_iters;
+  int max_iters;  /**< Maximum iterations (default: 0/optimiser default, range: >=0) */
   // cppcheck-suppress unusedStructMember
-  int max_evals;
+  int max_evals;  /**< Maximum evaluations (default: 0/optimiser default, range: >=0) */
   // cppcheck-suppress unusedStructMember
-  real weight;
+  real weight;    /**< Differential weight F (default: 0.8, range: (0, 2]) */
   // cppcheck-suppress unusedStructMember
-  real crossover;
+  real crossover; /**< Crossover probability CR (default: 0.9, range: [0, 1]) */
   // cppcheck-suppress unusedStructMember
-  real init_span;
+  real init_span; /**< Initial span per dimension (default: dpos or 1.0, range: >0) */
   // cppcheck-suppress unusedStructMember
-  uint64_t seed;  /**< RNG seed (0 = use default) */
+  uint64_t seed;  /**< RNG seed (0 = use internal default) */
 } sr_de_cfg;
 
 /**

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -184,7 +184,7 @@ typedef struct sr_de_cfg {
   real weight;
   real crossover;
   real init_span;
-  unsigned long long seed;
+  uint64_t seed;  /**< RNG seed (0 = use default) */
 } sr_de_cfg;
 
 /**
@@ -203,7 +203,7 @@ void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos);
  * @param evals In/out evaluation counter (may be NULL).
  * @return 0 on success, non-zero on failure.
  */
-int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
+int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(const real *),
                    real *best, real *best_val, int *evals);
 
 /* Drivers */

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -177,6 +177,12 @@ int sr_pso_optimize(const sr_pso_cfg *cfg, int ndim, real (*func)(const real *),
 /**
  * @brief Configuration for differential evolution (DE).
  */
+typedef enum sr_de_conv_mode {
+  SR_DE_CONV_NONE = 0,  /**< Disable convergence-based early stopping. */
+  SR_DE_CONV_NONNEG,    /**< Stop when 0 <= best_val <= conv_tol. */
+  SR_DE_CONV_ABS        /**< Stop when |best_val| <= conv_tol. */
+} sr_de_conv_mode;
+
 typedef struct sr_de_cfg {
   // cppcheck-suppress unusedStructMember
   int population; /**< Population size (default: 10*ndim, min: 20, range: >0) */
@@ -190,6 +196,10 @@ typedef struct sr_de_cfg {
   real crossover; /**< Crossover probability CR (default: 0.9, range: [0, 1]) */
   // cppcheck-suppress unusedStructMember
   real init_span; /**< Initial span per dimension (default: dpos or 1.0, range: >0) */
+  // cppcheck-suppress unusedStructMember
+  real conv_tol;  /**< Convergence tolerance (default: R_TOLERANCE, range: >0) */
+  // cppcheck-suppress unusedStructMember
+  sr_de_conv_mode conv_mode; /**< Convergence check mode (default: NONNEG). */
   // cppcheck-suppress unusedStructMember
   uint64_t seed;  /**< RNG seed (0 = use internal default) */
 } sr_de_cfg;

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -48,9 +48,10 @@ extern "C" {
  * @param nfunk In/out evaluation counter (legacy API).
  * @return 0 on success, non-zero on failure.
  */
-int sr_amoeba(real **p, real *y, int ndim, real ftol, real (*funk)(real *), int *nfunk);
+int sr_amoeba(real **p, real *y, int ndim, real ftol,
+              real (*funk)(const real *), int *nfunk);
 
-typedef real (*sr_amebsa_func)(real *);
+typedef real (*sr_amebsa_func)(const real *);
 
 /**
  * @brief Configuration for @ref sr_amebsa.
@@ -106,7 +107,7 @@ int sr_amebsa(real **p, real *y, int ndim, real *pb, real *yb,
  * @return 0 on success, non-zero on failure.
  */
 int sr_powell(real *p, real **xi, int n, real ftol, int *iter, real *fret,
-              real (*func)(real *));
+              real (*func)(const real *));
 ///@}
 
 /**
@@ -236,7 +237,7 @@ void sr_er(int ndim, real dpos, const char *bak_file, const char *log_file);
 /* file input|output */
 real sr_ckgeo(real *);
 int  sr_ckrot(struct sratom_str *, struct search_str *);
-real sr_evalrf(real *);
+real sr_evalrf(const real *);
 int  sr_mkinp(real *, int, char *);
 int  sr_rdinp(const char *);
 int  sr_rdver(const char *, real *, real **, int);

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -178,17 +178,26 @@ int sr_pso_optimize(const sr_pso_cfg *cfg, int ndim, real (*func)(const real *),
  * @brief Configuration for differential evolution (DE).
  */
 typedef struct sr_de_cfg {
+  // cppcheck-suppress unusedStructMember
   int population;
+  // cppcheck-suppress unusedStructMember
   int max_iters;
+  // cppcheck-suppress unusedStructMember
   int max_evals;
+  // cppcheck-suppress unusedStructMember
   real weight;
+  // cppcheck-suppress unusedStructMember
   real crossover;
+  // cppcheck-suppress unusedStructMember
   real init_span;
+  // cppcheck-suppress unusedStructMember
   uint64_t seed;  /**< RNG seed (0 = use default) */
 } sr_de_cfg;
 
 /**
  * @brief Initialise DE defaults based on dimensionality and dpos.
+ *
+ * Weight (F) is clamped to (0, 2] and crossover (CR) to [0, 1].
  */
 void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos);
 

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -174,11 +174,44 @@ void sr_pso_cfg_init(sr_pso_cfg *cfg, int ndim, real dpos);
 int sr_pso_optimize(const sr_pso_cfg *cfg, int ndim, real (*func)(const real *),
                     real *best, real *best_val, int *evals);
 
+/**
+ * @brief Configuration for differential evolution (DE).
+ */
+typedef struct sr_de_cfg {
+  int population;
+  int max_iters;
+  int max_evals;
+  real weight;
+  real crossover;
+  real init_span;
+  unsigned long long seed;
+} sr_de_cfg;
+
+/**
+ * @brief Initialise DE defaults based on dimensionality and dpos.
+ */
+void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos);
+
+/**
+ * @brief Differential evolution (DE) minimiser.
+ *
+ * @param cfg Configuration (may be NULL for defaults).
+ * @param ndim Dimensionality of the parameter vector.
+ * @param func Objective function.
+ * @param best Output best point (`1..ndim`).
+ * @param best_val Output best function value.
+ * @param evals In/out evaluation counter (may be NULL).
+ * @return 0 on success, non-zero on failure.
+ */
+int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
+                   real *best, real *best_val, int *evals);
+
 /* Drivers */
 void sr_sa(int ndim, real dpos, const char *bak_file, const char *log_file);
 void sr_sx(int ndim, real dpos, const char *bak_file, const char *log_file);
 void sr_po(int ndim, const char *bak_file, const char *log_file);
 void sr_pso(int ndim, real dpos, const char *bak_file, const char *log_file);
+void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file);
 void sr_er(int ndim, real dpos, const char *bak_file, const char *log_file);
 
 /* file input|output */

--- a/src/include/search_func.h
+++ b/src/include/search_func.h
@@ -235,10 +235,11 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file);
 void sr_er(int ndim, real dpos, const char *bak_file, const char *log_file);
 
 /* file input|output */
-real sr_ckgeo(real *);
+real sr_ckgeo(const real *);
 int  sr_ckrot(struct sratom_str *, struct search_str *);
 real sr_evalrf(const real *);
-int  sr_mkinp(real *, int, char *);
+int  sr_mkinp(const real *, int, char *);
+int  sr_mkinp_mir(const real *, int, char *);
 int  sr_rdinp(const char *);
 int  sr_rdver(const char *, real *, real **, int);
 

--- a/src/include/search_optimizer.h
+++ b/src/include/search_optimizer.h
@@ -37,6 +37,10 @@ typedef struct sr_optimizer_config {
   real pso_c2;
   // cppcheck-suppress unusedStructMember
   real pso_vmax;
+  int de_population;
+  real de_weight;
+  real de_crossover;
+  real de_init_span;
 } sr_optimizer_config;
 
 typedef struct sr_optimizer_def {

--- a/src/include/search_optimizer.h
+++ b/src/include/search_optimizer.h
@@ -37,9 +37,13 @@ typedef struct sr_optimizer_config {
   real pso_c2;
   // cppcheck-suppress unusedStructMember
   real pso_vmax;
+  // cppcheck-suppress unusedStructMember
   int de_population;
+  // cppcheck-suppress unusedStructMember
   real de_weight;
+  // cppcheck-suppress unusedStructMember
   real de_crossover;
+  // cppcheck-suppress unusedStructMember
   real de_init_span;
 } sr_optimizer_config;
 

--- a/src/include/sr_simplex.h
+++ b/src/include/sr_simplex.h
@@ -100,7 +100,8 @@ void sr_simplex_buffers_free(sr_simplex_buffers *b);
  * @param func Objective function to evaluate at each vertex.
  * @return 0 on success, non-zero on invalid inputs.
  */
-int sr_simplex_build_initial(sr_simplex_buffers *b, real dpos, real (*func)(real *));
+int sr_simplex_build_initial(sr_simplex_buffers *b, real dpos,
+                             real (*func)(const real *));
 
 /**
  * @brief Populate simplex buffers by reading a vertex file via sr_rdver().

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -40,6 +40,7 @@ SET (searchlib_SRCS
 	    sr_optimizers.c
 	    sr_simplex.c
 	    srpso.c
+	    srde.c
 	    sr_vertex_stats.c
 	    sr_amoeba.c
 	    sr_amebsa.c

--- a/src/search/Makefile.am
+++ b/src/search/Makefile.am
@@ -19,6 +19,7 @@ libsearch_la_SOURCES =      \
     sr_parse.c              \
     sr_optimizers.c         \
     srpso.c                 \
+    srde.c                  \
     sr_vertex_stats.c       \
     sr_amoeba.c             \
     sr_amebsa.c             \

--- a/src/search/Makefile.gcc
+++ b/src/search/Makefile.gcc
@@ -55,6 +55,7 @@ SRLIB  =  sr_alloc.o \
           sr_parse.o \
           sr_optimizers.o \
           srpso.o \
+          srde.o \
           sr_vertex_stats.o \
           sr_amoeba.o \
           sr_amebsa.o \

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -84,6 +84,30 @@ static real sr_parse_positive_real(const char *value, const char *invalid_msg)
   return (real)parsed;
 }
 
+static int sr_parse_required_positive_int(int argc, char *argv[], int *i_arg,
+                                          const char *missing_msg,
+                                          const char *invalid_msg)
+{
+  const char *value = sr_consume_arg(argc, argv, i_arg, missing_msg);
+  return sr_parse_positive_int(value, invalid_msg);
+}
+
+static uint64_t sr_parse_required_seed(int argc, char *argv[], int *i_arg,
+                                       const char *missing_msg,
+                                       const char *invalid_msg)
+{
+  const char *value = sr_consume_arg(argc, argv, i_arg, missing_msg);
+  return sr_parse_seed(value, invalid_msg);
+}
+
+static real sr_parse_required_positive_real(int argc, char *argv[], int *i_arg,
+                                            const char *missing_msg,
+                                            const char *invalid_msg)
+{
+  const char *value = sr_consume_arg(argc, argv, i_arg, missing_msg);
+  return sr_parse_positive_real(value, invalid_msg);
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -196,97 +220,97 @@ int main(int argc, char *argv[])
     }
 
     if (strcmp(argv[i_arg], "--max-evals") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): max evals value not given\n");
-      opt_cfg.max_evals = sr_parse_positive_int(value,
+      opt_cfg.max_evals = sr_parse_required_positive_int(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): max evals value not given\n",
           "*** error (SEARCH): invalid max evals value\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--max-iters") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): max iters value not given\n");
-      opt_cfg.max_iters = sr_parse_positive_int(value,
+      opt_cfg.max_iters = sr_parse_required_positive_int(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): max iters value not given\n",
           "*** error (SEARCH): invalid max iters value\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--seed") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): seed value not given\n");
-      opt_cfg.seed = sr_parse_seed(value,
+      opt_cfg.seed = sr_parse_required_seed(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): seed value not given\n",
           "*** error (SEARCH): invalid seed value\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--pso-swarm") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): PSO swarm size not given\n");
-      opt_cfg.pso_swarm_size = sr_parse_positive_int(value,
+      opt_cfg.pso_swarm_size = sr_parse_required_positive_int(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): PSO swarm size not given\n",
           "*** error (SEARCH): invalid PSO swarm size\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--pso-inertia") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): PSO inertia not given\n");
-      opt_cfg.pso_inertia = sr_parse_positive_real(value,
+      opt_cfg.pso_inertia = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): PSO inertia not given\n",
           "*** error (SEARCH): invalid PSO inertia\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--pso-c1") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): PSO c1 not given\n");
-      opt_cfg.pso_c1 = sr_parse_positive_real(value,
+      opt_cfg.pso_c1 = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): PSO c1 not given\n",
           "*** error (SEARCH): invalid PSO c1\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--pso-c2") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): PSO c2 not given\n");
-      opt_cfg.pso_c2 = sr_parse_positive_real(value,
+      opt_cfg.pso_c2 = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): PSO c2 not given\n",
           "*** error (SEARCH): invalid PSO c2\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--pso-vmax") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): PSO vmax not given\n");
-      opt_cfg.pso_vmax = sr_parse_positive_real(value,
+      opt_cfg.pso_vmax = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): PSO vmax not given\n",
           "*** error (SEARCH): invalid PSO vmax\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--de-pop") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): DE population not given\n");
-      opt_cfg.de_population = sr_parse_positive_int(value,
+      opt_cfg.de_population = sr_parse_required_positive_int(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): DE population not given\n",
           "*** error (SEARCH): invalid DE population\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--de-weight") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): DE weight not given\n");
-      opt_cfg.de_weight = sr_parse_positive_real(value,
+      opt_cfg.de_weight = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): DE weight not given\n",
           "*** error (SEARCH): invalid DE weight\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--de-cr") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): DE crossover not given\n");
-      opt_cfg.de_crossover = sr_parse_positive_real(value,
+      opt_cfg.de_crossover = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): DE crossover not given\n",
           "*** error (SEARCH): invalid DE crossover rate\n");
       continue;
     }
 
     if (strcmp(argv[i_arg], "--de-span") == 0) {
-      const char *value = sr_consume_arg(argc, argv, &i_arg,
-          "*** error (SEARCH): DE span not given\n");
-      opt_cfg.de_init_span = sr_parse_positive_real(value,
+      opt_cfg.de_init_span = sr_parse_required_positive_real(
+          argc, argv, &i_arg,
+          "*** error (SEARCH): DE span not given\n",
           "*** error (SEARCH): invalid DE span\n");
       continue;
     }

--- a/src/search/csearch.c
+++ b/src/search/csearch.c
@@ -259,6 +259,38 @@ int main(int argc, char *argv[])
       continue;
     }
 
+    if (strcmp(argv[i_arg], "--de-pop") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): DE population not given\n");
+      opt_cfg.de_population = sr_parse_positive_int(value,
+          "*** error (SEARCH): invalid DE population\n");
+      continue;
+    }
+
+    if (strcmp(argv[i_arg], "--de-weight") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): DE weight not given\n");
+      opt_cfg.de_weight = sr_parse_positive_real(value,
+          "*** error (SEARCH): invalid DE weight\n");
+      continue;
+    }
+
+    if (strcmp(argv[i_arg], "--de-cr") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): DE crossover not given\n");
+      opt_cfg.de_crossover = sr_parse_positive_real(value,
+          "*** error (SEARCH): invalid DE crossover rate\n");
+      continue;
+    }
+
+    if (strcmp(argv[i_arg], "--de-span") == 0) {
+      const char *value = sr_consume_arg(argc, argv, &i_arg,
+          "*** error (SEARCH): DE span not given\n");
+      opt_cfg.de_init_span = sr_parse_positive_real(value,
+          "*** error (SEARCH): invalid DE span\n");
+      continue;
+    }
+
     /* help */
     if ((strcmp(argv[i_arg], "-h") == 0) ||
         (strcmp(argv[i_arg], "--help") == 0)) {

--- a/src/search/search_globals.c
+++ b/src/search/search_globals.c
@@ -20,3 +20,5 @@ real sr_pso_inertia = (real)0.0;
 real sr_pso_c1 = (real)0.0;
 real sr_pso_c2 = (real)0.0;
 real sr_pso_vmax = (real)0.0;
+int sr_de_eval_limit = MAX_EVAL_DE;
+int sr_de_iter_limit = MAX_ITER_DE;

--- a/src/search/search_globals.c
+++ b/src/search/search_globals.c
@@ -22,3 +22,7 @@ real sr_pso_c2 = (real)0.0;
 real sr_pso_vmax = (real)0.0;
 int sr_de_eval_limit = MAX_EVAL_DE;
 int sr_de_iter_limit = MAX_ITER_DE;
+int sr_de_population = 0;
+real sr_de_weight = (real)0.0;
+real sr_de_crossover = (real)0.0;
+real sr_de_init_span = (real)0.0;

--- a/src/search/sr_amoeba.c
+++ b/src/search/sr_amoeba.c
@@ -95,7 +95,7 @@ typedef struct sr_amoeba_ctx {
   real rho;
   real sigma;
   real ftol;
-  real (*funk)(real *);
+  real (*funk)(const real *);
   int *nfunk;
   int max_evals;
   real **p;
@@ -215,7 +215,7 @@ static int sr_amoeba_alloc_buffers(sr_amoeba_ctx *ctx, int ndim)
 }
 
 static int sr_amoeba_init(sr_amoeba_ctx *ctx, real **p, real *y, int ndim,
-                          real ftol, real (*funk)(real *), int *nfunk)
+                          real ftol, real (*funk)(const real *), int *nfunk)
 {
   if (ctx == NULL || p == NULL || y == NULL || ndim <= 0 || funk == NULL || nfunk == NULL) return -1;
 
@@ -263,7 +263,8 @@ static int sr_amoeba_run(sr_amoeba_ctx *ctx)
   return rc;
 }
 
-int sr_amoeba(real **p, real *y, int ndim, real ftol, real (*funk)(real *), int *nfunk)
+int sr_amoeba(real **p, real *y, int ndim, real ftol,
+              real (*funk)(const real *), int *nfunk)
 {
   sr_amoeba_ctx ctx;
   int rc = sr_amoeba_init(&ctx, p, y, ndim, ftol, funk, nfunk);

--- a/src/search/sr_amoeba.c
+++ b/src/search/sr_amoeba.c
@@ -105,7 +105,7 @@ typedef struct sr_amoeba_ctx {
   real *trial2;
 } sr_amoeba_ctx;
 
-static real sr_amoeba_eval(sr_amoeba_ctx *ctx, real *x)
+static real sr_amoeba_eval(sr_amoeba_ctx *ctx, const real *x)
 {
   real v = ctx->funk(x);
   (*ctx->nfunk)++;

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -283,10 +283,14 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
     sr_powell_iter_limit = MAX_ITER_POWELL;
     sr_sa_iter_limit = MAX_ITER_SA;
     sr_pso_iter_limit = MAX_ITER_PSO;
+    sr_de_iter_limit = MAX_ITER_DE;
   }
   if (cfg->max_evals > 0) {
     sr_pso_eval_limit = cfg->max_evals;
     sr_de_eval_limit = cfg->max_evals;
+  } else {
+    sr_pso_eval_limit = MAX_EVAL_PSO;
+    sr_de_eval_limit = MAX_EVAL_DE;
   }
   sa_idum = (cfg->seed > 0) ? cfg->seed : 0;
   if (cfg->pso_swarm_size > 0) {

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -200,6 +200,10 @@ void sr_optimizer_config_init(sr_optimizer_config *cfg)
   cfg->pso_c1 = (real)0.0;
   cfg->pso_c2 = (real)0.0;
   cfg->pso_vmax = (real)0.0;
+  cfg->de_population = 0;
+  cfg->de_weight = (real)0.0;
+  cfg->de_crossover = (real)0.0;
+  cfg->de_init_span = (real)0.0;
 }
 
 static int sr_optimizer_read_int_env(const char *name, int *out_value)
@@ -260,6 +264,10 @@ void sr_optimizer_config_from_env(sr_optimizer_config *cfg)
   (void)sr_optimizer_read_real_env("CSEARCH_PSO_C1", &cfg->pso_c1);
   (void)sr_optimizer_read_real_env("CSEARCH_PSO_C2", &cfg->pso_c2);
   (void)sr_optimizer_read_real_env("CSEARCH_PSO_VMAX", &cfg->pso_vmax);
+  (void)sr_optimizer_read_int_env("CSEARCH_DE_POP", &cfg->de_population);
+  (void)sr_optimizer_read_real_env("CSEARCH_DE_WEIGHT", &cfg->de_weight);
+  (void)sr_optimizer_read_real_env("CSEARCH_DE_CR", &cfg->de_crossover);
+  (void)sr_optimizer_read_real_env("CSEARCH_DE_SPAN", &cfg->de_init_span);
 }
 
 void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
@@ -295,6 +303,18 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
   }
   if (cfg->pso_vmax > 0.0) {
     sr_pso_vmax = cfg->pso_vmax;
+  }
+  if (cfg->de_population > 0) {
+    sr_de_population = cfg->de_population;
+  }
+  if (cfg->de_weight > 0.0) {
+    sr_de_weight = cfg->de_weight;
+  }
+  if (cfg->de_crossover > 0.0) {
+    sr_de_crossover = cfg->de_crossover;
+  }
+  if (cfg->de_init_span > 0.0) {
+    sr_de_init_span = cfg->de_init_span;
   }
 }
 
@@ -370,6 +390,30 @@ void sr_optimizer_log_config(FILE *output, const sr_optimizer_config *cfg)
     fprintf(output, " pso_vmax=%.3f", (double)cfg->pso_vmax);
   } else {
     fprintf(output, " pso_vmax=default");
+  }
+
+  if (cfg->de_population > 0) {
+    fprintf(output, " de_pop=%d", cfg->de_population);
+  } else {
+    fprintf(output, " de_pop=default");
+  }
+
+  if (cfg->de_weight > 0.0) {
+    fprintf(output, " de_weight=%.3f", (double)cfg->de_weight);
+  } else {
+    fprintf(output, " de_weight=default");
+  }
+
+  if (cfg->de_crossover > 0.0) {
+    fprintf(output, " de_cr=%.3f", (double)cfg->de_crossover);
+  } else {
+    fprintf(output, " de_cr=default");
+  }
+
+  if (cfg->de_init_span > 0.0) {
+    fprintf(output, " de_span=%.3f", (double)cfg->de_init_span);
+  } else {
+    fprintf(output, " de_span=default");
   }
 
   fprintf(output, "\n");

--- a/src/search/sr_optimizers.c
+++ b/src/search/sr_optimizers.c
@@ -67,6 +67,13 @@ static int sr_run_pso(int ndim, real dpos, const char *bak_file,
   return 0;
 }
 
+static int sr_run_de(int ndim, real dpos, const char *bak_file,
+                     const char *log_file)
+{
+  sr_de(ndim, dpos, bak_file, log_file);
+  return 0;
+}
+
 static const sr_optimizer_entry sr_optimizers[] = {
     {
         .def = {
@@ -137,6 +144,20 @@ static const sr_optimizer_entry sr_optimizers[] = {
         },
         .aliases = {"ps", "pso", "swarm", NULL},
         .run = sr_run_pso,
+    },
+    {
+        .def = {
+            .name = "differential evolution",
+            .primary = "de",
+            .description = "differential evolution",
+            .aliases_help = "de, differential",
+            .type = SR_DIFFERENTIAL_EVOLUTION,
+            .implemented = 1,
+            .uses_delta = 1,
+            .is_default = 0,
+        },
+        .aliases = {"de", "differential", "differential-evolution", NULL},
+        .run = sr_run_de,
     },
 };
 
@@ -249,6 +270,7 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
     sr_powell_iter_limit = cfg->max_iters;
     sr_sa_iter_limit = cfg->max_iters;
     sr_pso_iter_limit = cfg->max_iters;
+    sr_de_iter_limit = cfg->max_iters;
   } else {
     sr_powell_iter_limit = MAX_ITER_POWELL;
     sr_sa_iter_limit = MAX_ITER_SA;
@@ -256,6 +278,7 @@ void sr_optimizer_config_apply(const sr_optimizer_config *cfg)
   }
   if (cfg->max_evals > 0) {
     sr_pso_eval_limit = cfg->max_evals;
+    sr_de_eval_limit = cfg->max_evals;
   }
   sa_idum = (cfg->seed > 0) ? cfg->seed : 0;
   if (cfg->pso_swarm_size > 0) {

--- a/src/search/sr_powell.c
+++ b/src/search/sr_powell.c
@@ -47,7 +47,7 @@ typedef struct sr_line_ctx {
   real *p0;         /* base point (1..n) */
   real *dir;        /* direction (1..n) */
   real *tmp;        /* scratch (1..n) */
-  real (*func)(real *);   /* objective */
+  real (*func)(const real *);   /* objective */
 } sr_line_ctx;
 
 static real sr_line_eval(real alpha, void *vctx)
@@ -302,7 +302,7 @@ static real sr_brent_minimise(real ax, real bx, real cx,
   return s.fx;
 }
 
-static int sr_linmin(real *p, real *dir, int n, real *fret, real (*func)(real *))
+static int sr_linmin(real *p, real *dir, int n, real *fret, real (*func)(const real *))
 {
   sr_line_ctx ctx;
   ctx.n = n;
@@ -356,7 +356,7 @@ static void sr_powell_free_work(real *p_prev, real *p_extrap, real *dir)
   sr_free_vector(p_prev);
 }
 
-static int sr_powell_minimise_all_directions(real *p, real **xi, int n, real *fret, real (*func)(real *),
+static int sr_powell_minimise_all_directions(real *p, real **xi, int n, real *fret, real (*func)(const real *),
                                              real *dir, int *out_best_dir)
 {
   real biggest_drop = 0.0;
@@ -397,7 +397,7 @@ typedef struct sr_powell_update_ctx {
   real **xi;
   int n;
   real *fret;
-  real (*func)(real *);
+  real (*func)(const real *);
   real *dir;
 } sr_powell_update_ctx;
 
@@ -419,7 +419,7 @@ typedef struct sr_powell_run_ctx {
   int n;
   real ftol;
   real *fret;
-  real (*func)(real *);
+  real (*func)(const real *);
   real *p_prev;
   real *p_extrap;
   real *dir;
@@ -468,7 +468,7 @@ static int sr_powell_run(sr_powell_run_ctx *ctx, int *iter)
 }
 
 int sr_powell(real *p, real **xi, int n, real ftol, int *iter,
-              real *fret, real (*func)(real *))
+              real *fret, real (*func)(const real *))
 {
   if (p == NULL) return -1;
   if (xi == NULL) return -1;

--- a/src/search/sr_simplex.c
+++ b/src/search/sr_simplex.c
@@ -128,7 +128,8 @@ static void sr_simplex_build_vertex(sr_simplex_buffers *b, int i, real dpos)
   }
 }
 
-int sr_simplex_build_initial(sr_simplex_buffers *b, real dpos, real (*func)(real *))
+int sr_simplex_build_initial(sr_simplex_buffers *b, real dpos,
+                             real (*func)(const real *))
 {
   if (b == NULL || b->p == NULL || b->y == NULL || b->x == NULL || b->ndim <= 0 || func == NULL) return -1;
 

--- a/src/search/srckgeo.c
+++ b/src/search/srckgeo.c
@@ -31,7 +31,7 @@ extern struct sratom_str *sr_atoms;
 extern struct search_str *sr_search;
 extern char *sr_project;
 
-real sr_ckgeo(real *par)
+real sr_ckgeo(const real *par)
 
 /***********************************************************************
 

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -1,0 +1,256 @@
+/***********************************************************************
+ *                        SRDE.C
+ *
+ *  Differential Evolution (DE) driver + core routine.
+ ***********************************************************************/
+
+// cppcheck-suppress missingIncludeSystem
+#include <math.h>
+// cppcheck-suppress missingIncludeSystem
+#include <stdio.h>
+// cppcheck-suppress missingIncludeSystem
+#include <stdlib.h>
+
+#include "search.h"
+#include "sr_alloc.h"
+#include "sr_rng.h"
+
+static int sr_de_default_population(int ndim)
+{
+  const int base = 10 * ndim;
+  return (base < 20) ? 20 : base;
+}
+
+void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
+{
+  if (!cfg) return;
+  cfg->population = sr_de_default_population(ndim);
+  cfg->max_iters = 0;
+  cfg->max_evals = 0;
+  cfg->weight = (real)0.8;
+  cfg->crossover = (real)0.9;
+  cfg->init_span = (dpos > 0.0) ? dpos : (real)1.0;
+  cfg->seed = 0;
+}
+
+static real sr_de_rand_span(sr_rng *rng, real span)
+{
+  const real u = (real)sr_rng_uniform01(rng);
+  return (u * (real)2.0 - (real)1.0) * span;
+}
+
+static int sr_de_pick_indices(sr_rng *rng, int pop, int skip,
+                              int *a, int *b, int *c)
+{
+  if (!rng || !a || !b || !c || pop < 4) return -1;
+
+  do {
+    *a = 1 + (int)(sr_rng_uniform01(rng) * pop);
+  } while (*a == skip);
+
+  do {
+    *b = 1 + (int)(sr_rng_uniform01(rng) * pop);
+  } while (*b == skip || *b == *a);
+
+  do {
+    *c = 1 + (int)(sr_rng_uniform01(rng) * pop);
+  } while (*c == skip || *c == *a || *c == *b);
+
+  return 0;
+}
+
+static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
+                                 real **pop_vec, real *scores, real *best,
+                                 real *best_val, real (*func)(real *), int *evals)
+{
+  if (!rng || !pop_vec || !scores || !best || !best_val || !func) return -1;
+
+  *best_val = 0.0;
+  for (int i = 1; i <= pop; i++) {
+    for (int j = 1; j <= ndim; j++) {
+      pop_vec[i][j] = sr_de_rand_span(rng, span);
+    }
+    scores[i] = (*func)(pop_vec[i]);
+    if (evals) (*evals)++;
+
+    if (i == 1 || scores[i] < *best_val) {
+      *best_val = scores[i];
+      for (int j = 1; j <= ndim; j++) {
+        best[j] = pop_vec[i][j];
+      }
+    }
+  }
+
+  return 0;
+}
+
+int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
+                   real *best, real *best_val, int *evals)
+{
+  if (!cfg || !func || !best || !best_val || ndim <= 0) {
+    return -1;
+  }
+
+  int pop = (cfg->population > 0) ? cfg->population : sr_de_default_population(ndim);
+  if (pop < 4) {
+    return -1;
+  }
+
+  const int max_iters = (cfg->max_iters > 0) ? cfg->max_iters : MAX_ITER_DE;
+  const int max_evals = (cfg->max_evals > 0) ? cfg->max_evals : MAX_EVAL_DE;
+  real weight = (cfg->weight > 0.0) ? cfg->weight : (real)0.8;
+  real cr = (cfg->crossover > 0.0) ? cfg->crossover : (real)0.9;
+  if (cr > (real)1.0) {
+    cr = (real)1.0;
+  }
+  const real span = (cfg->init_span > 0.0) ? cfg->init_span : (real)1.0;
+
+  sr_rng rng;
+  const unsigned long long seed = (cfg->seed > 0) ? cfg->seed : 1ULL;
+  sr_rng_seed(&rng, (uint64_t)seed);
+
+  real **pop_vec = sr_alloc_matrix((size_t)pop, (size_t)ndim);
+  real *scores = sr_alloc_vector((size_t)pop);
+  real *trial = sr_alloc_vector((size_t)ndim);
+
+  if (!pop_vec || !scores || !trial) {
+    sr_free_matrix(pop_vec);
+    sr_free_vector(scores);
+    sr_free_vector(trial);
+    return -1;
+  }
+
+  int local_evals = 0;
+  if (sr_de_init_population(&rng, pop, ndim, span, pop_vec, scores, best,
+                            best_val, func, &local_evals) != 0) {
+    sr_free_matrix(pop_vec);
+    sr_free_vector(scores);
+    sr_free_vector(trial);
+    return -1;
+  }
+
+  int iter = 0;
+  while (iter < max_iters && local_evals < max_evals) {
+    iter++;
+    for (int i = 1; i <= pop; i++) {
+      int a = 0;
+      int b = 0;
+      int c = 0;
+      int j_rand = 1 + (int)(sr_rng_uniform01(&rng) * ndim);
+      if (j_rand < 1) j_rand = 1;
+
+      if (sr_de_pick_indices(&rng, pop, i, &a, &b, &c) != 0) {
+        sr_free_matrix(pop_vec);
+        sr_free_vector(scores);
+        sr_free_vector(trial);
+        return -1;
+      }
+
+      for (int j = 1; j <= ndim; j++) {
+        const real r = (real)sr_rng_uniform01(&rng);
+        if (r < cr || j == j_rand) {
+          trial[j] = pop_vec[a][j] + weight * (pop_vec[b][j] - pop_vec[c][j]);
+        } else {
+          trial[j] = pop_vec[i][j];
+        }
+      }
+
+      const real f = (*func)(trial);
+      local_evals++;
+
+      if (f <= scores[i]) {
+        scores[i] = f;
+        for (int j = 1; j <= ndim; j++) {
+          pop_vec[i][j] = trial[j];
+        }
+        if (f < *best_val) {
+          *best_val = f;
+          for (int j = 1; j <= ndim; j++) {
+            best[j] = trial[j];
+          }
+        }
+      }
+
+      if (local_evals >= max_evals) {
+        break;
+      }
+    }
+
+    if (*best_val <= R_TOLERANCE) {
+      break;
+    }
+  }
+
+  if (evals) *evals = local_evals;
+
+  sr_free_matrix(pop_vec);
+  sr_free_vector(scores);
+  sr_free_vector(trial);
+
+  return 0;
+}
+
+static void sr_de_log_results(FILE *log_stream, int ndim, int evals,
+                              const real *best, real best_val)
+{
+  fprintf(log_stream, "\n=> No. of function evaluations in sr_de: %3d\n", evals);
+  fprintf(log_stream, "=> Best parameter set:\n");
+  for (int j = 1; j <= ndim; j++) {
+    fprintf(log_stream, "%.6f ", (double)best[j]);
+  }
+  fprintf(log_stream, "\n");
+  fprintf(log_stream, "=> Best function value:\n");
+  fprintf(log_stream, "rmin = %.6f\n", (double)best_val);
+}
+
+void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
+{
+  (void)bak_file;
+
+  sr_de_cfg cfg;
+  sr_de_cfg_init(&cfg, ndim, dpos);
+  cfg.max_iters = sr_de_iter_limit;
+  cfg.max_evals = sr_de_eval_limit;
+
+  if (sa_idum < 0) {
+    cfg.seed = (unsigned long long)(-sa_idum);
+  } else if (sa_idum > 0) {
+    cfg.seed = (unsigned long long)sa_idum;
+  }
+
+  real *best = sr_alloc_vector((size_t)ndim);
+  if (!best) {
+    fprintf(STDERR, "*** error (sr_de): allocation failure\n");
+    exit(1);
+  }
+
+  real best_val = 0.0;
+  int evals = 0;
+
+  FILE *log_stream = fopen(log_file, "a");
+  if (log_stream == NULL) {
+    sr_free_vector(best);
+    OPEN_ERROR(log_file);
+  }
+  fprintf(log_stream, "=> DIFFERENTIAL EVOLUTION:\n");
+  fprintf(log_stream, "=> pop=%d weight=%.3f cr=%.3f span=%.3f\n",
+          cfg.population, (double)cfg.weight, (double)cfg.crossover,
+          (double)cfg.init_span);
+  fclose(log_stream);
+
+  if (sr_de_optimize(&cfg, ndim, sr_evalrf, best, &best_val, &evals) != 0) {
+    sr_free_vector(best);
+    fprintf(STDERR, "*** error (sr_de): optimisation failed\n");
+    exit(1);
+  }
+
+  log_stream = fopen(log_file, "a");
+  if (log_stream == NULL) {
+    sr_free_vector(best);
+    OPEN_ERROR(log_file);
+  }
+  sr_de_log_results(log_stream, ndim, evals, best, best_val);
+  fclose(log_stream);
+
+  sr_free_vector(best);
+}

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -209,6 +209,18 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
 
   sr_de_cfg cfg;
   sr_de_cfg_init(&cfg, ndim, dpos);
+  if (sr_de_population > 0) {
+    cfg.population = sr_de_population;
+  }
+  if (sr_de_weight > 0.0) {
+    cfg.weight = sr_de_weight;
+  }
+  if (sr_de_crossover > 0.0) {
+    cfg.crossover = sr_de_crossover;
+  }
+  if (sr_de_init_span > 0.0) {
+    cfg.init_span = sr_de_init_span;
+  }
   cfg.max_iters = sr_de_iter_limit;
   cfg.max_evals = sr_de_eval_limit;
 

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -102,8 +102,8 @@ static int sr_de_pick_available(int pop, int skip)
   return available;
 }
 
-static int sr_de_validate_pick_inputs(sr_rng *rng, int pop, int skip,
-                                      int *a, int *b, int *c)
+static int sr_de_validate_pick_inputs(const sr_rng *rng, int pop, int skip,
+                                      const int *a, const int *b, const int *c)
 {
   if (!rng) return -1;
   if (!a) return -1;
@@ -525,19 +525,22 @@ static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
   if (!sr_de_run_inputs_ok(state, func, best, best_val)) return -1;
 
   int local_evals = 0;
+  int stop = 0;
   if (sr_de_init_population(state, best, best_val, func, &local_evals) != 0) {
     return -1;
   }
 
   for (int iter = 0; iter < state->max_iters; iter++) {
     if (local_evals >= state->max_evals) {
-      break;
-    }
-    if (sr_de_run_generation(state, func, best, best_val, &local_evals) != 0) {
+      stop = 1;
+    } else if (sr_de_run_generation(state, func, best, best_val,
+                                    &local_evals) != 0) {
       return -1;
+    } else if (sr_de_should_stop(state, *best_val)) {
+      stop = 1;
     }
 
-    if (sr_de_should_stop(state, *best_val)) {
+    if (stop) {
       break;
     }
   }

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -35,6 +35,8 @@ typedef struct sr_de_state {
   real weight;
   real crossover;
   real span;
+  real conv_tol;
+  sr_de_conv_mode conv_mode;
   real **pop_vec;
   real *scores;
   real *trial;
@@ -77,6 +79,11 @@ static real sr_de_rand_span(sr_rng *rng, real span)
 {
   const real u = (real)sr_rng_uniform01(rng);
   return (u * (real)2.0 - (real)1.0) * span;
+}
+
+static real sr_de_abs(real value)
+{
+  return (value < (real)0.0) ? -value : value;
 }
 
 /**
@@ -173,36 +180,44 @@ static void sr_de_copy_vector(real *dest, const real *src, int ndim)
  * @param evals    In/out evaluation counter.
  * @return 0 on success, -1 on invalid parameters.
  */
+static void sr_de_fill_vector(sr_de_state *state, real *dest)
+{
+  const int ndim = state->ndim;
+  const real span = state->span;
+
+  for (int j = 1; j <= ndim; j++) {
+    dest[j] = sr_de_rand_span(&state->rng, span);
+  }
+}
+
+static real sr_de_eval_vector(real (*func)(const real *), const real *vec,
+                              int *evals)
+{
+  const real value = (*func)(vec);
+  if (evals) (*evals)++;
+  return value;
+}
+
 static int sr_de_init_population(sr_de_state *state, real *best, real *best_val,
                                  real (*func)(const real *), int *evals)
 {
   if (!state || !best || !best_val || !func) return -1;
 
-  sr_rng *rng = &state->rng;
   const int pop = state->pop;
   const int ndim = state->ndim;
-  const real span = state->span;
-  real **pop_vec = state->pop_vec;
-  real *scores = state->scores;
 
-  for (int j = 1; j <= ndim; j++) {
-    pop_vec[1][j] = sr_de_rand_span(rng, span);
-  }
-  scores[1] = (*func)(pop_vec[1]);
-  if (evals) (*evals)++;
-  *best_val = scores[1];
-  sr_de_copy_vector(best, pop_vec[1], ndim);
+  sr_de_fill_vector(state, state->pop_vec[1]);
+  state->scores[1] = sr_de_eval_vector(func, state->pop_vec[1], evals);
+  *best_val = state->scores[1];
+  sr_de_copy_vector(best, state->pop_vec[1], ndim);
 
   for (int i = 2; i <= pop; i++) {
-    for (int j = 1; j <= ndim; j++) {
-      pop_vec[i][j] = sr_de_rand_span(rng, span);
-    }
-    scores[i] = (*func)(pop_vec[i]);
-    if (evals) (*evals)++;
+    sr_de_fill_vector(state, state->pop_vec[i]);
+    state->scores[i] = sr_de_eval_vector(func, state->pop_vec[i], evals);
 
-    if (scores[i] < *best_val) {
-      *best_val = scores[i];
-      sr_de_copy_vector(best, pop_vec[i], ndim);
+    if (state->scores[i] < *best_val) {
+      *best_val = state->scores[i];
+      sr_de_copy_vector(best, state->pop_vec[i], ndim);
     }
   }
 
@@ -330,6 +345,54 @@ static const sr_de_cfg *sr_de_get_effective_cfg(const sr_de_cfg *cfg,
   return cfg;
 }
 
+static int sr_de_resolve_population(const sr_de_cfg *src, int ndim, int *out)
+{
+  if (!out || ndim <= 0) return -1;
+
+  *out = (src->population > 0) ? src->population
+                               : sr_de_default_population(ndim);
+  if (*out < 4) return -1;
+
+  return 0;
+}
+
+static int sr_de_resolve_limit(int value, int default_value)
+{
+  return (value > 0) ? value : default_value;
+}
+
+static real sr_de_resolve_weight(real weight)
+{
+  if (weight <= (real)0.0) return (real)0.8;
+  if (weight > (real)2.0) return (real)2.0;
+  return weight;
+}
+
+static real sr_de_resolve_crossover(real crossover)
+{
+  if (crossover < (real)0.0) return (real)0.0;
+  if (crossover > (real)1.0) return (real)1.0;
+  return crossover;
+}
+
+static real sr_de_resolve_span(real span)
+{
+  return (span > (real)0.0) ? span : (real)1.0;
+}
+
+static real sr_de_resolve_conv_tol(real conv_tol)
+{
+  return (conv_tol > (real)0.0) ? conv_tol : (real)R_TOLERANCE;
+}
+
+static sr_de_conv_mode sr_de_resolve_conv_mode(sr_de_conv_mode mode)
+{
+  if (mode == SR_DE_CONV_NONE || mode == SR_DE_CONV_ABS) {
+    return mode;
+  }
+  return SR_DE_CONV_NONNEG;
+}
+
 static int sr_de_resolve_cfg(const sr_de_cfg *cfg, int ndim,
                              sr_de_cfg *resolved)
 {
@@ -338,31 +401,38 @@ static int sr_de_resolve_cfg(const sr_de_cfg *cfg, int ndim,
   sr_de_cfg defaults;
   const sr_de_cfg *src = sr_de_get_effective_cfg(cfg, &defaults, ndim);
 
-  resolved->population = (src->population > 0) ? src->population
-                                               : sr_de_default_population(ndim);
-  if (resolved->population < 4) return -1;
-
-  resolved->max_iters = (src->max_iters > 0) ? src->max_iters : MAX_ITER_DE;
-  resolved->max_evals = (src->max_evals > 0) ? src->max_evals : MAX_EVAL_DE;
-
-  resolved->weight = src->weight;
-  if (resolved->weight <= (real)0.0) {
-    resolved->weight = (real)0.8;
-  }
-  if (resolved->weight > (real)2.0) {
-    resolved->weight = (real)2.0;
+  if (sr_de_resolve_population(src, ndim, &resolved->population) != 0) {
+    return -1;
   }
 
-  resolved->crossover = src->crossover;
-  if (resolved->crossover < (real)0.0) {
-    resolved->crossover = (real)0.0;
-  }
-  if (resolved->crossover > (real)1.0) {
-    resolved->crossover = (real)1.0;
-  }
-
-  resolved->init_span = (src->init_span > (real)0.0) ? src->init_span : (real)1.0;
+  resolved->max_iters = sr_de_resolve_limit(src->max_iters, MAX_ITER_DE);
+  resolved->max_evals = sr_de_resolve_limit(src->max_evals, MAX_EVAL_DE);
+  resolved->weight = sr_de_resolve_weight(src->weight);
+  resolved->crossover = sr_de_resolve_crossover(src->crossover);
+  resolved->init_span = sr_de_resolve_span(src->init_span);
+  resolved->conv_tol = sr_de_resolve_conv_tol(src->conv_tol);
+  resolved->conv_mode = sr_de_resolve_conv_mode(src->conv_mode);
   resolved->seed = src->seed;
+
+  return 0;
+}
+
+static int sr_de_evolve_member(sr_de_state *state, int target,
+                               sr_de_selection_ctx *select_ctx,
+                               real (*func)(const real *), int *evals)
+{
+  int a = 0;
+  int b = 0;
+  int c = 0;
+
+  if (sr_de_pick_indices(&state->rng, state->pop, target, &a, &b, &c) != 0) {
+    return -1;
+  }
+
+  sr_de_create_trial(state, target, a, b, c);
+
+  const real trial_val = sr_de_eval_vector(func, state->trial, evals);
+  sr_de_selection(select_ctx, target, state->trial, trial_val);
 
   return 0;
 }
@@ -380,22 +450,24 @@ static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
   select_ctx.ndim = state->ndim;
 
   for (int i = 1; i <= state->pop && *evals < state->max_evals; i++) {
-    int a = 0;
-    int b = 0;
-    int c = 0;
-    if (sr_de_pick_indices(&state->rng, state->pop, i, &a, &b, &c) != 0) {
+    if (sr_de_evolve_member(state, i, &select_ctx, func, evals) != 0) {
       return -1;
     }
-
-    sr_de_create_trial(state, i, a, b, c);
-
-    const real trial_val = (*func)(state->trial);
-    (*evals)++;
-
-    sr_de_selection(&select_ctx, i, state->trial, trial_val);
   }
 
   return 0;
+}
+
+static int sr_de_should_stop(const sr_de_state *state, real best_val)
+{
+  if (!state || state->conv_mode == SR_DE_CONV_NONE) return 0;
+  if (state->conv_tol <= (real)0.0) return 0;
+
+  if (state->conv_mode == SR_DE_CONV_ABS) {
+    return sr_de_abs(best_val) <= state->conv_tol;
+  }
+
+  return best_val >= (real)0.0 && best_val <= state->conv_tol;
 }
 
 static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
@@ -415,7 +487,7 @@ static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
       return -1;
     }
 
-    if (*best_val >= (real)0.0 && *best_val <= R_TOLERANCE) {
+    if (sr_de_should_stop(state, *best_val)) {
       break;
     }
   }
@@ -439,6 +511,7 @@ static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
  * - Differential weight (F): 0.8 (clamped to (0, 2])
  * - Crossover probability (CR): 0.9 (clamped to [0, 1])
  * - Initial span: dpos or 1.0
+ * - Convergence tolerance: R_TOLERANCE (mode: non-negative only)
  *
  * @param cfg   Pointer to configuration structure to initialize.
  * @param ndim  Number of dimensions in the optimization problem.
@@ -453,6 +526,8 @@ void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
   cfg->weight = (real)0.8;
   cfg->crossover = (real)0.9;
   cfg->init_span = (dpos > 0.0) ? dpos : (real)1.0;
+  cfg->conv_tol = (real)R_TOLERANCE;
+  cfg->conv_mode = SR_DE_CONV_NONNEG;
   cfg->seed = 0;
   if (cfg->weight <= (real)0.0) cfg->weight = (real)0.8;
   if (cfg->weight > (real)2.0) cfg->weight = (real)2.0;
@@ -506,6 +581,8 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(const real *),
   state.weight = effective_cfg.weight;
   state.crossover = effective_cfg.crossover;
   state.span = effective_cfg.init_span;
+  state.conv_tol = effective_cfg.conv_tol;
+  state.conv_mode = effective_cfg.conv_mode;
   state.pop_vec = NULL;
   state.scores = NULL;
   state.trial = NULL;
@@ -548,6 +625,19 @@ static void sr_de_log_results(FILE *log_stream, int ndim, int evals,
   fprintf(log_stream, "rmin = %.6f\n", (double)best_val);
 }
 
+static const char *sr_de_conv_mode_label(sr_de_conv_mode mode)
+{
+  switch (mode) {
+    case SR_DE_CONV_NONE:
+      return "none";
+    case SR_DE_CONV_ABS:
+      return "abs";
+    case SR_DE_CONV_NONNEG:
+    default:
+      return "nonneg";
+  }
+}
+
 /**
  * @brief Log DE configuration parameters to a file stream.
  *
@@ -557,9 +647,11 @@ static void sr_de_log_results(FILE *log_stream, int ndim, int evals,
 static void sr_de_log_config(FILE *log_stream, const sr_de_cfg *cfg)
 {
   fprintf(log_stream, "=> DIFFERENTIAL EVOLUTION:\n");
-  fprintf(log_stream, "=> pop=%d weight=%.3f cr=%.3f span=%.3f\n",
+  fprintf(log_stream,
+          "=> pop=%d weight=%.3f cr=%.3f span=%.3f conv_tol=%.6f conv_mode=%s\n",
           cfg->population, (double)cfg->weight, (double)cfg->crossover,
-          (double)cfg->init_span);
+          (double)cfg->init_span, (double)cfg->conv_tol,
+          sr_de_conv_mode_label(cfg->conv_mode));
 }
 
 /**

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -766,8 +766,7 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
   /* Run optimization */
   real best_val = 0.0;
   int evals = 0;
-  if (sr_de_optimize(&effective_cfg, ndim, (real (*)(const real *))sr_evalrf,
-                     best, &best_val, &evals) != 0) {
+  if (sr_de_optimize(&effective_cfg, ndim, sr_evalrf, best, &best_val, &evals) != 0) {
     sr_free_vector(best);
     fprintf(STDERR, "*** error (sr_de): optimisation failed\n");
     exit(1);

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -18,8 +18,6 @@
  ***********************************************************************/
 
 // cppcheck-suppress missingIncludeSystem
-#include <math.h>
-// cppcheck-suppress missingIncludeSystem
 #include <stdio.h>
 // cppcheck-suppress missingIncludeSystem
 #include <stdlib.h>
@@ -27,6 +25,20 @@
 #include "search.h"
 #include "sr_alloc.h"
 #include "sr_rng.h"
+
+typedef struct sr_de_state {
+  sr_rng rng;
+  int pop;
+  int ndim;
+  int max_iters;
+  int max_evals;
+  real weight;
+  real crossover;
+  real span;
+  real **pop_vec;
+  real *scores;
+  real *trial;
+} sr_de_state;
 
 /*===========================================================================*/
 /* Internal helper functions                                                 */
@@ -73,22 +85,29 @@ static real sr_de_rand_span(sr_rng *rng, real span)
  * @param c    Output: third randomly selected index.
  * @return 0 on success, -1 on invalid parameters.
  */
+static int sr_de_pick_index(sr_rng *rng, int pop, int skip, int exclude1,
+                            int exclude2)
+{
+  int idx = 0;
+
+  do {
+    idx = 1 + (int)(sr_rng_uniform01(rng) * pop);
+  } while (idx == skip || idx == exclude1 || idx == exclude2);
+
+  return idx;
+}
+
 static int sr_de_pick_indices(sr_rng *rng, int pop, int skip,
                               int *a, int *b, int *c)
 {
   if (!rng || !a || !b || !c || pop < 4) return -1;
 
-  do {
-    *a = 1 + (int)(sr_rng_uniform01(rng) * pop);
-  } while (*a == skip);
+  const int excluded = (skip >= 1 && skip <= pop) ? 1 : 0;
+  if (pop - excluded < 3) return -1;
 
-  do {
-    *b = 1 + (int)(sr_rng_uniform01(rng) * pop);
-  } while (*b == skip || *b == *a);
-
-  do {
-    *c = 1 + (int)(sr_rng_uniform01(rng) * pop);
-  } while (*c == skip || *c == *a || *c == *b);
+  *a = sr_de_pick_index(rng, pop, skip, 0, 0);
+  *b = sr_de_pick_index(rng, pop, skip, *a, 0);
+  *c = sr_de_pick_index(rng, pop, skip, *a, *b);
 
   return 0;
 }
@@ -146,21 +165,34 @@ static void sr_de_copy_vector(real *dest, const real *src, int ndim)
  * @param evals    In/out evaluation counter.
  * @return 0 on success, -1 on invalid parameters.
  */
-static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
-                                 real **pop_vec, real *scores, real *best,
-                                 real *best_val, real (*func)(const real *), int *evals)
+static int sr_de_init_population(sr_de_state *state, real *best, real *best_val,
+                                 real (*func)(const real *), int *evals)
 {
-  if (!rng || !pop_vec || !scores || !best || !best_val || !func) return -1;
+  if (!state || !best || !best_val || !func) return -1;
 
-  *best_val = 0.0;
-  for (int i = 1; i <= pop; i++) {
+  sr_rng *rng = &state->rng;
+  const int pop = state->pop;
+  const int ndim = state->ndim;
+  const real span = state->span;
+  real **pop_vec = state->pop_vec;
+  real *scores = state->scores;
+
+  for (int j = 1; j <= ndim; j++) {
+    pop_vec[1][j] = sr_de_rand_span(rng, span);
+  }
+  scores[1] = (*func)(pop_vec[1]);
+  if (evals) (*evals)++;
+  *best_val = scores[1];
+  sr_de_copy_vector(best, pop_vec[1], ndim);
+
+  for (int i = 2; i <= pop; i++) {
     for (int j = 1; j <= ndim; j++) {
       pop_vec[i][j] = sr_de_rand_span(rng, span);
     }
     scores[i] = (*func)(pop_vec[i]);
     if (evals) (*evals)++;
 
-    if (i == 1 || scores[i] < *best_val) {
+    if (scores[i] < *best_val) {
       *best_val = scores[i];
       sr_de_copy_vector(best, pop_vec[i], ndim);
     }
@@ -186,12 +218,21 @@ static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
  * @param ndim    Number of dimensions.
  * @param trial   Output: trial vector.
  */
-static void sr_de_create_trial(sr_rng *rng, real **pop_vec, int target,
-                               int a, int b, int c, real weight, real cr,
-                               int ndim, real *trial)
+static void sr_de_create_trial(sr_de_state *state, int target,
+                               int a, int b, int c)
 {
+  if (!state) return;
+
+  sr_rng *rng = &state->rng;
+  real **pop_vec = state->pop_vec;
+  const int ndim = state->ndim;
+  const real weight = state->weight;
+  const real cr = state->crossover;
+  real *trial = state->trial;
+
   int j_rand = 1 + (int)(sr_rng_uniform01(rng) * ndim);
   if (j_rand < 1) j_rand = 1;
+  if (j_rand > ndim) j_rand = ndim;
 
   for (int j = 1; j <= ndim; j++) {
     const real r = (real)sr_rng_uniform01(rng);
@@ -284,6 +325,95 @@ static const sr_de_cfg *sr_de_get_effective_cfg(const sr_de_cfg *cfg,
   return cfg;
 }
 
+static int sr_de_resolve_cfg(const sr_de_cfg *cfg, int ndim,
+                             sr_de_cfg *resolved)
+{
+  if (!resolved || ndim <= 0) return -1;
+
+  sr_de_cfg defaults;
+  const sr_de_cfg *src = sr_de_get_effective_cfg(cfg, &defaults, ndim);
+
+  resolved->population = (src->population > 0) ? src->population
+                                               : sr_de_default_population(ndim);
+  if (resolved->population < 4) return -1;
+
+  resolved->max_iters = (src->max_iters > 0) ? src->max_iters : MAX_ITER_DE;
+  resolved->max_evals = (src->max_evals > 0) ? src->max_evals : MAX_EVAL_DE;
+
+  resolved->weight = src->weight;
+  if (resolved->weight <= (real)0.0) {
+    resolved->weight = (real)0.8;
+  }
+  if (resolved->weight > (real)2.0) {
+    resolved->weight = (real)2.0;
+  }
+
+  resolved->crossover = src->crossover;
+  if (resolved->crossover < (real)0.0) {
+    resolved->crossover = (real)0.0;
+  }
+  if (resolved->crossover > (real)1.0) {
+    resolved->crossover = (real)1.0;
+  }
+
+  resolved->init_span = (src->init_span > (real)0.0) ? src->init_span : (real)1.0;
+  resolved->seed = (src->seed > 0) ? src->seed : 1ULL;
+
+  return 0;
+}
+
+static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
+                                real *best, real *best_val, int *evals)
+{
+  if (!state || !func || !best || !best_val || !evals) return -1;
+
+  for (int i = 1; i <= state->pop && *evals < state->max_evals; i++) {
+    int a, b, c;
+    if (sr_de_pick_indices(&state->rng, state->pop, i, &a, &b, &c) != 0) {
+      return -1;
+    }
+
+    sr_de_create_trial(state, i, a, b, c);
+
+    const real trial_val = (*func)(state->trial);
+    (*evals)++;
+
+    sr_de_selection(state->pop_vec, state->scores, i, state->trial,
+                    trial_val, best, best_val, state->ndim);
+  }
+
+  return 0;
+}
+
+static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
+                     real *best_val, int *evals)
+{
+  if (!state || !func || !best || !best_val) return -1;
+
+  int local_evals = 0;
+  if (sr_de_init_population(state, best, best_val, func, &local_evals) != 0) {
+    return -1;
+  }
+
+  for (int iter = 0;
+       iter < state->max_iters && local_evals < state->max_evals;
+       iter++) {
+    if (sr_de_run_generation(state, func, best, best_val, &local_evals) != 0) {
+      return -1;
+    }
+
+    if (*best_val >= (real)0.0 && *best_val <= R_TOLERANCE) {
+      break;
+    }
+  }
+
+  if (evals) {
+    *evals = local_evals;
+  }
+
+  return 0;
+}
+
 /*===========================================================================*/
 /* Public API                                                                */
 /*===========================================================================*/
@@ -293,8 +423,8 @@ static const sr_de_cfg *sr_de_get_effective_cfg(const sr_de_cfg *cfg,
  *
  * Sets up default hyperparameters suitable for LEED optimization:
  * - Population: 10 × ndim (minimum 20)
- * - Differential weight (F): 0.8
- * - Crossover probability (CR): 0.9
+ * - Differential weight (F): 0.8 (clamped to (0, 2])
+ * - Crossover probability (CR): 0.9 (clamped to [0, 1])
  * - Initial span: dpos or 1.0
  *
  * @param cfg   Pointer to configuration structure to initialize.
@@ -311,6 +441,10 @@ void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
   cfg->crossover = (real)0.9;
   cfg->init_span = (dpos > 0.0) ? dpos : (real)1.0;
   cfg->seed = 0;
+  if (cfg->weight <= (real)0.0) cfg->weight = (real)0.8;
+  if (cfg->weight > (real)2.0) cfg->weight = (real)2.0;
+  if (cfg->crossover < (real)0.0) cfg->crossover = (real)0.0;
+  if (cfg->crossover > (real)1.0) cfg->crossover = (real)1.0;
 }
 
 /**
@@ -345,72 +479,37 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(const real *),
     return -1;
   }
 
-  /* Apply defaults if no config provided */
-  sr_de_cfg defaults;
-  cfg = sr_de_get_effective_cfg(cfg, &defaults, ndim);
-
-  /* Extract and validate parameters */
-  int pop = (cfg->population > 0) ? cfg->population : sr_de_default_population(ndim);
-  if (pop < 4) {
+  sr_de_cfg effective_cfg;
+  if (sr_de_resolve_cfg(cfg, ndim, &effective_cfg) != 0) {
     return -1;
   }
-
-  const int max_iters = (cfg->max_iters > 0) ? cfg->max_iters : MAX_ITER_DE;
-  const int max_evals = (cfg->max_evals > 0) ? cfg->max_evals : MAX_EVAL_DE;
-  real weight = (cfg->weight > 0.0) ? cfg->weight : (real)0.8;
-  real cr = (cfg->crossover > 0.0) ? cfg->crossover : (real)0.9;
-  if (cr > (real)1.0) {
-    cr = (real)1.0;
-  }
-  const real span = (cfg->init_span > 0.0) ? cfg->init_span : (real)1.0;
 
   /* Initialize RNG */
-  sr_rng rng;
-  const uint64_t seed = (cfg->seed > 0) ? cfg->seed : 1ULL;
-  sr_rng_seed(&rng, (uint64_t)seed);
+  sr_de_state state;
+  state.pop = effective_cfg.population;
+  state.ndim = ndim;
+  state.max_iters = effective_cfg.max_iters;
+  state.max_evals = effective_cfg.max_evals;
+  state.weight = effective_cfg.weight;
+  state.crossover = effective_cfg.crossover;
+  state.span = effective_cfg.init_span;
+  state.pop_vec = NULL;
+  state.scores = NULL;
+  state.trial = NULL;
+  sr_rng_seed(&state.rng, (uint64_t)effective_cfg.seed);
 
   /* Allocate working memory */
-  real **pop_vec = NULL;
-  real *scores = NULL;
-  real *trial = NULL;
-  if (sr_de_alloc_memory(pop, ndim, &pop_vec, &scores, &trial) != 0) {
+  if (sr_de_alloc_memory(state.pop, state.ndim, &state.pop_vec,
+                         &state.scores, &state.trial) != 0) {
     return -1;
   }
 
-  /* Initialize population */
-  int local_evals = 0;
-  if (sr_de_init_population(&rng, pop, ndim, span, pop_vec, scores, best,
-                            best_val, func, &local_evals) != 0) {
-    sr_de_free_memory(pop_vec, scores, trial);
+  if (sr_de_run(&state, func, best, best_val, evals) != 0) {
+    sr_de_free_memory(state.pop_vec, state.scores, state.trial);
     return -1;
   }
 
-  /* Main evolution loop */
-  for (int iter = 0; iter < max_iters && local_evals < max_evals; iter++) {
-    for (int i = 1; i <= pop && local_evals < max_evals; i++) {
-      int a, b, c;
-      if (sr_de_pick_indices(&rng, pop, i, &a, &b, &c) != 0) {
-        sr_de_free_memory(pop_vec, scores, trial);
-        return -1;
-      }
-
-      sr_de_create_trial(&rng, pop_vec, i, a, b, c, weight, cr, ndim, trial);
-
-      const real trial_val = (*func)(trial);
-      local_evals++;
-
-      sr_de_selection(pop_vec, scores, i, trial, trial_val, best, best_val, ndim);
-    }
-
-    /* Early termination on convergence */
-    if (*best_val <= R_TOLERANCE) {
-      break;
-    }
-  }
-
-  if (evals) *evals = local_evals;
-
-  sr_de_free_memory(pop_vec, scores, trial);
+  sr_de_free_memory(state.pop_vec, state.scores, state.trial);
   return 0;
 }
 
@@ -479,10 +578,8 @@ static void sr_de_build_config(sr_de_cfg *cfg, int ndim, real dpos)
   cfg->max_iters = sr_de_iter_limit;
   cfg->max_evals = sr_de_eval_limit;
 
-  if (sa_idum < 0) {
-    cfg->seed = (uint64_t)(-sa_idum);
-  } else if (sa_idum > 0) {
-    cfg->seed = (uint64_t)sa_idum;
+  if (sa_idum != 0) {
+    cfg->seed = (uint64_t)(sa_idum < 0 ? -sa_idum : sa_idum);
   }
 }
 
@@ -505,6 +602,11 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
   /* Build configuration from globals */
   sr_de_cfg cfg;
   sr_de_build_config(&cfg, ndim, dpos);
+  sr_de_cfg effective_cfg;
+  if (sr_de_resolve_cfg(&cfg, ndim, &effective_cfg) != 0) {
+    fprintf(STDERR, "*** error (sr_de): invalid configuration\n");
+    exit(1);
+  }
 
   /* Allocate result vector */
   real *best = sr_alloc_vector((size_t)ndim);
@@ -520,13 +622,14 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
     OPEN_ERROR(log_file);
     exit(1);  /* Ensure exit if OPEN_ERROR doesn't */
   }
-  sr_de_log_config(log_stream, &cfg);
+  sr_de_log_config(log_stream, &effective_cfg);
   fclose(log_stream);
 
   /* Run optimization */
   real best_val = 0.0;
   int evals = 0;
-  if (sr_de_optimize(&cfg, ndim, (real (*)(const real *))sr_evalrf, best, &best_val, &evals) != 0) {
+  if (sr_de_optimize(&effective_cfg, ndim, (real (*)(const real *))sr_evalrf,
+                     best, &best_val, &evals) != 0) {
     sr_free_vector(best);
     fprintf(STDERR, "*** error (sr_de): optimisation failed\n");
     exit(1);

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -86,14 +86,31 @@ static real sr_de_abs(real value)
   return (value < (real)0.0) ? -value : value;
 }
 
+static int sr_de_skip_excludes(int skip, int pop)
+{
+  if (skip < 1) return 0;
+  if (skip > pop) return 0;
+  return 1;
+}
+
+static int sr_de_pick_available(int pop, int skip)
+{
+  int available = pop;
+  if (sr_de_skip_excludes(skip, pop)) {
+    available -= 1;
+  }
+  return available;
+}
+
 static int sr_de_validate_pick_inputs(sr_rng *rng, int pop, int skip,
                                       int *a, int *b, int *c)
 {
-  if (!rng || !a || !b || !c) return -1;
+  if (!rng) return -1;
+  if (!a) return -1;
+  if (!b) return -1;
+  if (!c) return -1;
   if (pop < 4) return -1;
-
-  const int excluded = (skip >= 1 && skip <= pop) ? 1 : 0;
-  if (pop - excluded < 3) return -1;
+  if (sr_de_pick_available(pop, skip) < 3) return -1;
 
   return 0;
 }

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -582,10 +582,6 @@ void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
   cfg->conv_tol = (real)R_TOLERANCE;
   cfg->conv_mode = SR_DE_CONV_NONNEG;
   cfg->seed = 0;
-  if (cfg->weight <= (real)0.0) cfg->weight = (real)0.8;
-  if (cfg->weight > (real)2.0) cfg->weight = (real)2.0;
-  if (cfg->crossover < (real)0.0) cfg->crossover = (real)0.0;
-  if (cfg->crossover > (real)1.0) cfg->crossover = (real)1.0;
 }
 
 /**

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -1,7 +1,20 @@
 /***********************************************************************
- *                        SRDE.C
+ * @file srde.c
+ * @brief Differential Evolution (DE) optimizer implementation.
  *
- *  Differential Evolution (DE) driver + core routine.
+ * This file implements the DE/rand/1/bin variant of the Differential
+ * Evolution algorithm for global optimization. DE is a population-based
+ * stochastic optimizer that evolves candidate solutions using vector
+ * differences.
+ *
+ * @par Algorithm Reference:
+ * Storn, R., & Price, K. (1997). Differential Evolution – A Simple and
+ * Efficient Heuristic for Global Optimization over Continuous Spaces.
+ * Journal of Global Optimization, 11, 341–359.
+ * https://doi.org/10.1023/A:1008202821328
+ *
+ * @author CLEED Development Team
+ * @date 2025
  ***********************************************************************/
 
 // cppcheck-suppress missingIncludeSystem
@@ -15,30 +28,51 @@
 #include "sr_alloc.h"
 #include "sr_rng.h"
 
+/*===========================================================================*/
+/* Internal helper functions                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief Compute default population size based on problem dimensionality.
+ *
+ * Uses the heuristic of 10 individuals per dimension, with a minimum of 20.
+ *
+ * @param ndim Number of dimensions in the optimization problem.
+ * @return Recommended population size.
+ */
 static int sr_de_default_population(int ndim)
 {
   const int base = 10 * ndim;
   return (base < 20) ? 20 : base;
 }
 
-void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
-{
-  if (!cfg) return;
-  cfg->population = sr_de_default_population(ndim);
-  cfg->max_iters = 0;
-  cfg->max_evals = 0;
-  cfg->weight = (real)0.8;
-  cfg->crossover = (real)0.9;
-  cfg->init_span = (dpos > 0.0) ? dpos : (real)1.0;
-  cfg->seed = 0;
-}
-
+/**
+ * @brief Generate a random value uniformly distributed in [-span, +span].
+ *
+ * @param rng  Pointer to the random number generator state.
+ * @param span Half-width of the uniform distribution.
+ * @return Random value in the range [-span, +span].
+ */
 static real sr_de_rand_span(sr_rng *rng, real span)
 {
   const real u = (real)sr_rng_uniform01(rng);
   return (u * (real)2.0 - (real)1.0) * span;
 }
 
+/**
+ * @brief Select three distinct random indices for DE mutation.
+ *
+ * Selects indices a, b, c from [1, pop] such that none equal skip or
+ * each other. This is used to form the DE/rand/1 mutant vector.
+ *
+ * @param rng  Pointer to the random number generator state.
+ * @param pop  Population size.
+ * @param skip Index to exclude (typically the current target vector).
+ * @param a    Output: first randomly selected index.
+ * @param b    Output: second randomly selected index.
+ * @param c    Output: third randomly selected index.
+ * @return 0 on success, -1 on invalid parameters.
+ */
 static int sr_de_pick_indices(sr_rng *rng, int pop, int skip,
                               int *a, int *b, int *c)
 {
@@ -59,6 +93,59 @@ static int sr_de_pick_indices(sr_rng *rng, int pop, int skip,
   return 0;
 }
 
+/**
+ * @brief Update the global best solution if a new best is found.
+ *
+ * @param trial     Trial vector that may be the new best.
+ * @param trial_val Objective value of the trial vector.
+ * @param best      Current best solution vector (updated if improved).
+ * @param best_val  Current best objective value (updated if improved).
+ * @param ndim      Number of dimensions.
+ */
+static void sr_de_update_best(const real *trial, real trial_val,
+                              real *best, real *best_val, int ndim)
+{
+  if (trial_val < *best_val) {
+    *best_val = trial_val;
+    for (int j = 1; j <= ndim; j++) {
+      best[j] = trial[j];
+    }
+  }
+}
+
+/**
+ * @brief Copy a vector from source to destination.
+ *
+ * @param dest Destination vector (1-indexed).
+ * @param src  Source vector (1-indexed).
+ * @param ndim Number of dimensions.
+ */
+static void sr_de_copy_vector(real *dest, const real *src, int ndim)
+{
+  for (int j = 1; j <= ndim; j++) {
+    dest[j] = src[j];
+  }
+}
+
+/**
+ * @brief Initialize the DE population with random solutions.
+ *
+ * Each individual is initialized with random values in [-span, +span]
+ * for each dimension. The best solution found during initialization
+ * is tracked.
+ *
+ * @param rng      Pointer to the random number generator state.
+ * @param pop      Population size.
+ * @param ndim     Number of dimensions.
+ * @param span     Initial search span for each dimension.
+ * @param pop_vec  Population matrix (pop × ndim, 1-indexed).
+ * @param scores   Objective values for each individual (1-indexed).
+ * @param best     Output: best solution vector found.
+ * @param best_val Output: best objective value found.
+ * @param func     Objective function to minimize.
+ * @param evals    In/out evaluation counter.
+ * @return 0 on success, -1 on invalid parameters.
+ */
 static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
                                  real **pop_vec, real *scores, real *best,
                                  real *best_val, real (*func)(real *), int *evals)
@@ -75,15 +162,182 @@ static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
 
     if (i == 1 || scores[i] < *best_val) {
       *best_val = scores[i];
-      for (int j = 1; j <= ndim; j++) {
-        best[j] = pop_vec[i][j];
-      }
+      sr_de_copy_vector(best, pop_vec[i], ndim);
     }
   }
 
   return 0;
 }
 
+/**
+ * @brief Create a trial vector using DE/rand/1/bin crossover.
+ *
+ * Generates a trial vector by combining the mutant vector (formed from
+ * three random individuals) with the target vector using binomial crossover.
+ *
+ * @param rng     Pointer to the random number generator state.
+ * @param pop_vec Population matrix.
+ * @param target  Index of the target vector.
+ * @param a       Index of first mutant base vector.
+ * @param b       Index of second mutant base vector.
+ * @param c       Index of third mutant base vector.
+ * @param weight  Differential weight (scaling factor F).
+ * @param cr      Crossover probability.
+ * @param ndim    Number of dimensions.
+ * @param trial   Output: trial vector.
+ */
+static void sr_de_create_trial(sr_rng *rng, real **pop_vec, int target,
+                               int a, int b, int c, real weight, real cr,
+                               int ndim, real *trial)
+{
+  int j_rand = 1 + (int)(sr_rng_uniform01(rng) * ndim);
+  if (j_rand < 1) j_rand = 1;
+
+  for (int j = 1; j <= ndim; j++) {
+    const real r = (real)sr_rng_uniform01(rng);
+    if (r < cr || j == j_rand) {
+      /* Mutant: v = x_a + F * (x_b - x_c) */
+      trial[j] = pop_vec[a][j] + weight * (pop_vec[b][j] - pop_vec[c][j]);
+    } else {
+      /* Inherit from target */
+      trial[j] = pop_vec[target][j];
+    }
+  }
+}
+
+/**
+ * @brief Perform selection: replace target if trial is at least as good.
+ *
+ * @param pop_vec   Population matrix.
+ * @param scores    Objective values array.
+ * @param target    Index of the target vector.
+ * @param trial     Trial vector.
+ * @param trial_val Objective value of the trial vector.
+ * @param best      Global best solution vector.
+ * @param best_val  Global best objective value.
+ * @param ndim      Number of dimensions.
+ */
+static void sr_de_selection(real **pop_vec, real *scores, int target,
+                            const real *trial, real trial_val,
+                            real *best, real *best_val, int ndim)
+{
+  if (trial_val <= scores[target]) {
+    scores[target] = trial_val;
+    sr_de_copy_vector(pop_vec[target], trial, ndim);
+    sr_de_update_best(trial, trial_val, best, best_val, ndim);
+  }
+}
+
+/**
+ * @brief Free DE working memory.
+ *
+ * @param pop_vec Population matrix.
+ * @param scores  Scores vector.
+ * @param trial   Trial vector.
+ */
+static void sr_de_free_memory(real **pop_vec, real *scores, real *trial)
+{
+  sr_free_matrix(pop_vec);
+  sr_free_vector(scores);
+  sr_free_vector(trial);
+}
+
+/**
+ * @brief Allocate DE working memory.
+ *
+ * @param pop     Population size.
+ * @param ndim    Number of dimensions.
+ * @param pop_vec Output: population matrix.
+ * @param scores  Output: scores vector.
+ * @param trial   Output: trial vector.
+ * @return 0 on success, -1 on allocation failure.
+ */
+static int sr_de_alloc_memory(int pop, int ndim,
+                              real ***pop_vec, real **scores, real **trial)
+{
+  *pop_vec = sr_alloc_matrix((size_t)pop, (size_t)ndim);
+  *scores = sr_alloc_vector((size_t)pop);
+  *trial = sr_alloc_vector((size_t)ndim);
+
+  if (!*pop_vec || !*scores || !*trial) {
+    sr_de_free_memory(*pop_vec, *scores, *trial);
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * @brief Validate and apply default configuration values.
+ *
+ * @param cfg      Input configuration (may be NULL for defaults).
+ * @param defaults Output: configuration with defaults applied.
+ * @param ndim     Number of dimensions.
+ * @return Pointer to the effective configuration.
+ */
+static const sr_de_cfg *sr_de_get_effective_cfg(const sr_de_cfg *cfg,
+                                                 sr_de_cfg *defaults, int ndim)
+{
+  if (!cfg) {
+    sr_de_cfg_init(defaults, ndim, (real)1.0);
+    return defaults;
+  }
+  return cfg;
+}
+
+/*===========================================================================*/
+/* Public API                                                                */
+/*===========================================================================*/
+
+/**
+ * @brief Initialize a DE configuration structure with sensible defaults.
+ *
+ * Sets up default hyperparameters suitable for LEED optimization:
+ * - Population: 10 × ndim (minimum 20)
+ * - Differential weight (F): 0.8
+ * - Crossover probability (CR): 0.9
+ * - Initial span: dpos or 1.0
+ *
+ * @param cfg   Pointer to configuration structure to initialize.
+ * @param ndim  Number of dimensions in the optimization problem.
+ * @param dpos  Initial displacement (used for initial span).
+ */
+void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
+{
+  if (!cfg) return;
+  cfg->population = sr_de_default_population(ndim);
+  cfg->max_iters = 0;
+  cfg->max_evals = 0;
+  cfg->weight = (real)0.8;
+  cfg->crossover = (real)0.9;
+  cfg->init_span = (dpos > 0.0) ? dpos : (real)1.0;
+  cfg->seed = 0;
+}
+
+/**
+ * @brief Run the DE/rand/1/bin optimization algorithm.
+ *
+ * Performs Differential Evolution optimization to minimize the given
+ * objective function. The algorithm evolves a population of candidate
+ * solutions using mutation, crossover, and selection operators.
+ *
+ * @par Algorithm Steps:
+ * 1. Initialize population randomly within [-init_span, +init_span]
+ * 2. For each generation:
+ *    - For each target vector x_i:
+ *      - Select three distinct random vectors x_a, x_b, x_c
+ *      - Create mutant: v = x_a + F × (x_b - x_c)
+ *      - Create trial vector using binomial crossover
+ *      - If f(trial) ≤ f(x_i), replace x_i with trial
+ * 3. Continue until max iterations, max evaluations, or convergence
+ *
+ * @param cfg      Configuration structure (NULL for defaults).
+ * @param ndim     Number of dimensions.
+ * @param func     Objective function to minimize (1-indexed arrays).
+ * @param best     Output: best solution vector found.
+ * @param best_val Output: best objective value found.
+ * @param evals    Output: total number of function evaluations (may be NULL).
+ * @return 0 on success, -1 on failure.
+ */
 int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
                    real *best, real *best_val, int *evals)
 {
@@ -91,12 +345,11 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
     return -1;
   }
 
+  /* Apply defaults if no config provided */
   sr_de_cfg defaults;
-  if (!cfg) {
-    sr_de_cfg_init(&defaults, ndim, (real)1.0);
-    cfg = &defaults;
-  }
+  cfg = sr_de_get_effective_cfg(cfg, &defaults, ndim);
 
+  /* Extract and validate parameters */
   int pop = (cfg->population > 0) ? cfg->population : sr_de_default_population(ndim);
   if (pop < 4) {
     return -1;
@@ -111,77 +364,45 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
   }
   const real span = (cfg->init_span > 0.0) ? cfg->init_span : (real)1.0;
 
+  /* Initialize RNG */
   sr_rng rng;
   const unsigned long long seed = (cfg->seed > 0) ? cfg->seed : 1ULL;
   sr_rng_seed(&rng, (uint64_t)seed);
 
-  real **pop_vec = sr_alloc_matrix((size_t)pop, (size_t)ndim);
-  real *scores = sr_alloc_vector((size_t)pop);
-  real *trial = sr_alloc_vector((size_t)ndim);
-
-  if (!pop_vec || !scores || !trial) {
-    sr_free_matrix(pop_vec);
-    sr_free_vector(scores);
-    sr_free_vector(trial);
+  /* Allocate working memory */
+  real **pop_vec = NULL;
+  real *scores = NULL;
+  real *trial = NULL;
+  if (sr_de_alloc_memory(pop, ndim, &pop_vec, &scores, &trial) != 0) {
     return -1;
   }
 
+  /* Initialize population */
   int local_evals = 0;
   if (sr_de_init_population(&rng, pop, ndim, span, pop_vec, scores, best,
                             best_val, func, &local_evals) != 0) {
-    sr_free_matrix(pop_vec);
-    sr_free_vector(scores);
-    sr_free_vector(trial);
+    sr_de_free_memory(pop_vec, scores, trial);
     return -1;
   }
 
-  int iter = 0;
-  while (iter < max_iters && local_evals < max_evals) {
-    iter++;
-    for (int i = 1; i <= pop; i++) {
-      int a = 0;
-      int b = 0;
-      int c = 0;
-      int j_rand = 1 + (int)(sr_rng_uniform01(&rng) * ndim);
-      if (j_rand < 1) j_rand = 1;
-
+  /* Main evolution loop */
+  for (int iter = 0; iter < max_iters && local_evals < max_evals; iter++) {
+    for (int i = 1; i <= pop && local_evals < max_evals; i++) {
+      int a, b, c;
       if (sr_de_pick_indices(&rng, pop, i, &a, &b, &c) != 0) {
-        sr_free_matrix(pop_vec);
-        sr_free_vector(scores);
-        sr_free_vector(trial);
+        sr_de_free_memory(pop_vec, scores, trial);
         return -1;
       }
 
-      for (int j = 1; j <= ndim; j++) {
-        const real r = (real)sr_rng_uniform01(&rng);
-        if (r < cr || j == j_rand) {
-          trial[j] = pop_vec[a][j] + weight * (pop_vec[b][j] - pop_vec[c][j]);
-        } else {
-          trial[j] = pop_vec[i][j];
-        }
-      }
+      sr_de_create_trial(&rng, pop_vec, i, a, b, c, weight, cr, ndim, trial);
 
-      const real f = (*func)(trial);
+      const real trial_val = (*func)(trial);
       local_evals++;
 
-      if (f <= scores[i]) {
-        scores[i] = f;
-        for (int j = 1; j <= ndim; j++) {
-          pop_vec[i][j] = trial[j];
-        }
-        if (f < *best_val) {
-          *best_val = f;
-          for (int j = 1; j <= ndim; j++) {
-            best[j] = trial[j];
-          }
-        }
-      }
-
-      if (local_evals >= max_evals) {
-        break;
-      }
+      sr_de_selection(pop_vec, scores, i, trial, trial_val, best, best_val, ndim);
     }
 
+    /* Early termination on convergence */
     if (*best_val <= R_TOLERANCE) {
       break;
     }
@@ -189,13 +410,19 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
 
   if (evals) *evals = local_evals;
 
-  sr_free_matrix(pop_vec);
-  sr_free_vector(scores);
-  sr_free_vector(trial);
-
+  sr_de_free_memory(pop_vec, scores, trial);
   return 0;
 }
 
+/**
+ * @brief Log DE optimization results to a file stream.
+ *
+ * @param log_stream Output file stream.
+ * @param ndim       Number of dimensions.
+ * @param evals      Total function evaluations performed.
+ * @param best       Best solution vector found.
+ * @param best_val   Best objective value found.
+ */
 static void sr_de_log_results(FILE *log_stream, int ndim, int evals,
                               const real *best, real best_val)
 {
@@ -209,59 +436,102 @@ static void sr_de_log_results(FILE *log_stream, int ndim, int evals,
   fprintf(log_stream, "rmin = %.6f\n", (double)best_val);
 }
 
+/**
+ * @brief Log DE configuration parameters to a file stream.
+ *
+ * @param log_stream Output file stream.
+ * @param cfg        DE configuration.
+ */
+static void sr_de_log_config(FILE *log_stream, const sr_de_cfg *cfg)
+{
+  fprintf(log_stream, "=> DIFFERENTIAL EVOLUTION:\n");
+  fprintf(log_stream, "=> pop=%d weight=%.3f cr=%.3f span=%.3f\n",
+          cfg->population, (double)cfg->weight, (double)cfg->crossover,
+          (double)cfg->init_span);
+}
+
+/**
+ * @brief Build DE configuration from global variables.
+ *
+ * Constructs a sr_de_cfg structure by reading global configuration
+ * variables that may have been set via CLI or environment.
+ *
+ * @param cfg   Output: configuration structure.
+ * @param ndim  Number of dimensions.
+ * @param dpos  Initial displacement.
+ */
+static void sr_de_build_config(sr_de_cfg *cfg, int ndim, real dpos)
+{
+  sr_de_cfg_init(cfg, ndim, dpos);
+
+  if (sr_de_population > 0) {
+    cfg->population = sr_de_population;
+  }
+  if (sr_de_weight > 0.0) {
+    cfg->weight = sr_de_weight;
+  }
+  if (sr_de_crossover > 0.0) {
+    cfg->crossover = sr_de_crossover;
+  }
+  if (sr_de_init_span > 0.0) {
+    cfg->init_span = sr_de_init_span;
+  }
+  cfg->max_iters = sr_de_iter_limit;
+  cfg->max_evals = sr_de_eval_limit;
+
+  if (sa_idum < 0) {
+    cfg->seed = (unsigned long long)(-sa_idum);
+  } else if (sa_idum > 0) {
+    cfg->seed = (unsigned long long)sa_idum;
+  }
+}
+
+/**
+ * @brief DE optimizer entry point for the CLEED search subsystem.
+ *
+ * This is the main driver function called by the optimizer registry.
+ * It configures DE from global settings, runs the optimization, and
+ * logs results to the specified log file.
+ *
+ * @param ndim     Number of search dimensions.
+ * @param dpos     Initial displacement for parameter variations.
+ * @param bak_file Backup file path (unused, for API compatibility).
+ * @param log_file Log file path for recording optimization progress.
+ */
 void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
 {
   (void)bak_file;
 
+  /* Build configuration from globals */
   sr_de_cfg cfg;
-  sr_de_cfg_init(&cfg, ndim, dpos);
-  if (sr_de_population > 0) {
-    cfg.population = sr_de_population;
-  }
-  if (sr_de_weight > 0.0) {
-    cfg.weight = sr_de_weight;
-  }
-  if (sr_de_crossover > 0.0) {
-    cfg.crossover = sr_de_crossover;
-  }
-  if (sr_de_init_span > 0.0) {
-    cfg.init_span = sr_de_init_span;
-  }
-  cfg.max_iters = sr_de_iter_limit;
-  cfg.max_evals = sr_de_eval_limit;
+  sr_de_build_config(&cfg, ndim, dpos);
 
-  if (sa_idum < 0) {
-    cfg.seed = (unsigned long long)(-sa_idum);
-  } else if (sa_idum > 0) {
-    cfg.seed = (unsigned long long)sa_idum;
-  }
-
+  /* Allocate result vector */
   real *best = sr_alloc_vector((size_t)ndim);
   if (!best) {
     fprintf(STDERR, "*** error (sr_de): allocation failure\n");
     exit(1);
   }
 
-  real best_val = 0.0;
-  int evals = 0;
-
+  /* Log configuration */
   FILE *log_stream = fopen(log_file, "a");
   if (log_stream == NULL) {
     sr_free_vector(best);
     OPEN_ERROR(log_file);
   }
-  fprintf(log_stream, "=> DIFFERENTIAL EVOLUTION:\n");
-  fprintf(log_stream, "=> pop=%d weight=%.3f cr=%.3f span=%.3f\n",
-          cfg.population, (double)cfg.weight, (double)cfg.crossover,
-          (double)cfg.init_span);
+  sr_de_log_config(log_stream, &cfg);
   fclose(log_stream);
 
+  /* Run optimization */
+  real best_val = 0.0;
+  int evals = 0;
   if (sr_de_optimize(&cfg, ndim, sr_evalrf, best, &best_val, &evals) != 0) {
     sr_free_vector(best);
     fprintf(STDERR, "*** error (sr_de): optimisation failed\n");
     exit(1);
   }
 
+  /* Log results */
   log_stream = fopen(log_file, "a");
   if (log_stream == NULL) {
     sr_free_vector(best);

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -148,7 +148,7 @@ static void sr_de_copy_vector(real *dest, const real *src, int ndim)
  */
 static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
                                  real **pop_vec, real *scores, real *best,
-                                 real *best_val, real (*func)(real *), int *evals)
+                                 real *best_val, real (*func)(const real *), int *evals)
 {
   if (!rng || !pop_vec || !scores || !best || !best_val || !func) return -1;
 
@@ -338,7 +338,7 @@ void sr_de_cfg_init(sr_de_cfg *cfg, int ndim, real dpos)
  * @param evals    Output: total number of function evaluations (may be NULL).
  * @return 0 on success, -1 on failure.
  */
-int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
+int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(const real *),
                    real *best, real *best_val, int *evals)
 {
   if (!func || !best || !best_val || ndim <= 0) {
@@ -366,7 +366,7 @@ int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
 
   /* Initialize RNG */
   sr_rng rng;
-  const unsigned long long seed = (cfg->seed > 0) ? cfg->seed : 1ULL;
+  const uint64_t seed = (cfg->seed > 0) ? cfg->seed : 1ULL;
   sr_rng_seed(&rng, (uint64_t)seed);
 
   /* Allocate working memory */
@@ -480,9 +480,9 @@ static void sr_de_build_config(sr_de_cfg *cfg, int ndim, real dpos)
   cfg->max_evals = sr_de_eval_limit;
 
   if (sa_idum < 0) {
-    cfg->seed = (unsigned long long)(-sa_idum);
+    cfg->seed = (uint64_t)(-sa_idum);
   } else if (sa_idum > 0) {
-    cfg->seed = (unsigned long long)sa_idum;
+    cfg->seed = (uint64_t)sa_idum;
   }
 }
 
@@ -518,6 +518,7 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
   if (log_stream == NULL) {
     sr_free_vector(best);
     OPEN_ERROR(log_file);
+    exit(1);  /* Ensure exit if OPEN_ERROR doesn't */
   }
   sr_de_log_config(log_stream, &cfg);
   fclose(log_stream);
@@ -525,7 +526,7 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
   /* Run optimization */
   real best_val = 0.0;
   int evals = 0;
-  if (sr_de_optimize(&cfg, ndim, sr_evalrf, best, &best_val, &evals) != 0) {
+  if (sr_de_optimize(&cfg, ndim, (real (*)(const real *))sr_evalrf, best, &best_val, &evals) != 0) {
     sr_free_vector(best);
     fprintf(STDERR, "*** error (sr_de): optimisation failed\n");
     exit(1);
@@ -536,6 +537,7 @@ void sr_de(int ndim, real dpos, const char *bak_file, const char *log_file)
   if (log_stream == NULL) {
     sr_free_vector(best);
     OPEN_ERROR(log_file);
+    exit(1);  /* Ensure exit if OPEN_ERROR doesn't */
   }
   sr_de_log_results(log_stream, ndim, evals, best, best_val);
   fclose(log_stream);

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -519,30 +519,40 @@ static int sr_de_run_inputs_ok(const sr_de_state *state,
   return 1;
 }
 
+static int sr_de_run_step(sr_de_state *state, real (*func)(const real *),
+                          real *best, real *best_val, int *evals, int *stop)
+{
+  if (!stop) return -1;
+
+  if (*evals >= state->max_evals) {
+    *stop = 1;
+    return 0;
+  }
+
+  if (sr_de_run_generation(state, func, best, best_val, evals) != 0) {
+    return -1;
+  }
+
+  *stop = sr_de_should_stop(state, *best_val);
+  return 0;
+}
+
 static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
                      real *best_val, int *evals)
 {
   if (!sr_de_run_inputs_ok(state, func, best, best_val)) return -1;
 
   int local_evals = 0;
-  int stop = 0;
   if (sr_de_init_population(state, best, best_val, func, &local_evals) != 0) {
     return -1;
   }
 
   for (int iter = 0; iter < state->max_iters; iter++) {
-    if (local_evals >= state->max_evals) {
-      stop = 1;
-    } else if (sr_de_run_generation(state, func, best, best_val,
-                                    &local_evals) != 0) {
+    int stop = 0;
+    if (sr_de_run_step(state, func, best, best_val, &local_evals, &stop) != 0) {
       return -1;
-    } else if (sr_de_should_stop(state, *best_val)) {
-      stop = 1;
     }
-
-    if (stop) {
-      break;
-    }
+    if (stop) break;
   }
 
   if (evals) {

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -87,8 +87,14 @@ static int sr_de_init_population(sr_rng *rng, int pop, int ndim, real span,
 int sr_de_optimize(const sr_de_cfg *cfg, int ndim, real (*func)(real *),
                    real *best, real *best_val, int *evals)
 {
-  if (!cfg || !func || !best || !best_val || ndim <= 0) {
+  if (!func || !best || !best_val || ndim <= 0) {
     return -1;
+  }
+
+  sr_de_cfg defaults;
+  if (!cfg) {
+    sr_de_cfg_init(&defaults, ndim, (real)1.0);
+    cfg = &defaults;
   }
 
   int pop = (cfg->population > 0) ? cfg->population : sr_de_default_population(ndim);

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -86,6 +86,18 @@ static real sr_de_abs(real value)
   return (value < (real)0.0) ? -value : value;
 }
 
+static int sr_de_validate_pick_inputs(sr_rng *rng, int pop, int skip,
+                                      int *a, int *b, int *c)
+{
+  if (!rng || !a || !b || !c) return -1;
+  if (pop < 4) return -1;
+
+  const int excluded = (skip >= 1 && skip <= pop) ? 1 : 0;
+  if (pop - excluded < 3) return -1;
+
+  return 0;
+}
+
 /**
  * @brief Select three distinct random indices for DE mutation.
  *
@@ -115,10 +127,7 @@ static int sr_de_pick_index(sr_rng *rng, int pop, int skip, int exclude1,
 static int sr_de_pick_indices(sr_rng *rng, int pop, int skip,
                               int *a, int *b, int *c)
 {
-  if (!rng || !a || !b || !c || pop < 4) return -1;
-
-  const int excluded = (skip >= 1 && skip <= pop) ? 1 : 0;
-  if (pop - excluded < 3) return -1;
+  if (sr_de_validate_pick_inputs(rng, pop, skip, a, b, c) != 0) return -1;
 
   *a = sr_de_pick_index(rng, pop, skip, 0, 0);
   *b = sr_de_pick_index(rng, pop, skip, *a, 0);
@@ -437,10 +446,22 @@ static int sr_de_evolve_member(sr_de_state *state, int target,
   return 0;
 }
 
+static int sr_de_run_generation_inputs_ok(const sr_de_state *state,
+                                          real (*func)(const real *),
+                                          const real *best,
+                                          const real *best_val,
+                                          const int *evals)
+{
+  if (!state || !func || !best || !best_val || !evals) return 0;
+  return 1;
+}
+
 static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
                                 real *best, real *best_val, int *evals)
 {
-  if (!state || !func || !best || !best_val || !evals) return -1;
+  if (!sr_de_run_generation_inputs_ok(state, func, best, best_val, evals)) {
+    return -1;
+  }
 
   sr_de_selection_ctx select_ctx;
   select_ctx.pop_vec = state->pop_vec;
@@ -449,7 +470,10 @@ static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
   select_ctx.best_val = best_val;
   select_ctx.ndim = state->ndim;
 
-  for (int i = 1; i <= state->pop && *evals < state->max_evals; i++) {
+  for (int i = 1; i <= state->pop; i++) {
+    if (*evals >= state->max_evals) {
+      break;
+    }
     if (sr_de_evolve_member(state, i, &select_ctx, func, evals) != 0) {
       return -1;
     }
@@ -470,19 +494,28 @@ static int sr_de_should_stop(const sr_de_state *state, real best_val)
   return best_val >= (real)0.0 && best_val <= state->conv_tol;
 }
 
+static int sr_de_run_inputs_ok(const sr_de_state *state,
+                               real (*func)(const real *),
+                               const real *best, const real *best_val)
+{
+  if (!state || !func || !best || !best_val) return 0;
+  return 1;
+}
+
 static int sr_de_run(sr_de_state *state, real (*func)(const real *), real *best,
                      real *best_val, int *evals)
 {
-  if (!state || !func || !best || !best_val) return -1;
+  if (!sr_de_run_inputs_ok(state, func, best, best_val)) return -1;
 
   int local_evals = 0;
   if (sr_de_init_population(state, best, best_val, func, &local_evals) != 0) {
     return -1;
   }
 
-  for (int iter = 0;
-       iter < state->max_iters && local_evals < state->max_evals;
-       iter++) {
+  for (int iter = 0; iter < state->max_iters; iter++) {
+    if (local_evals >= state->max_evals) {
+      break;
+    }
     if (sr_de_run_generation(state, func, best, best_val, &local_evals) != 0) {
       return -1;
     }

--- a/src/search/srde.c
+++ b/src/search/srde.c
@@ -40,6 +40,14 @@ typedef struct sr_de_state {
   real *trial;
 } sr_de_state;
 
+typedef struct sr_de_selection_ctx {
+  real **pop_vec;
+  real *scores;
+  real *best;
+  real *best_val;
+  int ndim;
+} sr_de_selection_ctx;
+
 /*===========================================================================*/
 /* Internal helper functions                                                 */
 /*===========================================================================*/
@@ -249,23 +257,20 @@ static void sr_de_create_trial(sr_de_state *state, int target,
 /**
  * @brief Perform selection: replace target if trial is at least as good.
  *
- * @param pop_vec   Population matrix.
- * @param scores    Objective values array.
+ * @param ctx       Selection context (population, scores, best trackers).
  * @param target    Index of the target vector.
  * @param trial     Trial vector.
  * @param trial_val Objective value of the trial vector.
- * @param best      Global best solution vector.
- * @param best_val  Global best objective value.
- * @param ndim      Number of dimensions.
  */
-static void sr_de_selection(real **pop_vec, real *scores, int target,
-                            const real *trial, real trial_val,
-                            real *best, real *best_val, int ndim)
+static void sr_de_selection(sr_de_selection_ctx *ctx, int target,
+                            const real *trial, real trial_val)
 {
-  if (trial_val <= scores[target]) {
-    scores[target] = trial_val;
-    sr_de_copy_vector(pop_vec[target], trial, ndim);
-    sr_de_update_best(trial, trial_val, best, best_val, ndim);
+  if (!ctx || !trial) return;
+
+  if (trial_val <= ctx->scores[target]) {
+    ctx->scores[target] = trial_val;
+    sr_de_copy_vector(ctx->pop_vec[target], trial, ctx->ndim);
+    sr_de_update_best(trial, trial_val, ctx->best, ctx->best_val, ctx->ndim);
   }
 }
 
@@ -357,7 +362,7 @@ static int sr_de_resolve_cfg(const sr_de_cfg *cfg, int ndim,
   }
 
   resolved->init_span = (src->init_span > (real)0.0) ? src->init_span : (real)1.0;
-  resolved->seed = (src->seed > 0) ? src->seed : 1ULL;
+  resolved->seed = src->seed;
 
   return 0;
 }
@@ -367,8 +372,17 @@ static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
 {
   if (!state || !func || !best || !best_val || !evals) return -1;
 
+  sr_de_selection_ctx select_ctx;
+  select_ctx.pop_vec = state->pop_vec;
+  select_ctx.scores = state->scores;
+  select_ctx.best = best;
+  select_ctx.best_val = best_val;
+  select_ctx.ndim = state->ndim;
+
   for (int i = 1; i <= state->pop && *evals < state->max_evals; i++) {
-    int a, b, c;
+    int a = 0;
+    int b = 0;
+    int c = 0;
     if (sr_de_pick_indices(&state->rng, state->pop, i, &a, &b, &c) != 0) {
       return -1;
     }
@@ -378,8 +392,7 @@ static int sr_de_run_generation(sr_de_state *state, real (*func)(const real *),
     const real trial_val = (*func)(state->trial);
     (*evals)++;
 
-    sr_de_selection(state->pop_vec, state->scores, i, state->trial,
-                    trial_val, best, best_val, state->ndim);
+    sr_de_selection(&select_ctx, i, state->trial, trial_val);
   }
 
   return 0;

--- a/src/search/srevalrf.c
+++ b/src/search/srevalrf.c
@@ -132,7 +132,7 @@ FILE *io_stream, *log_stream;
  fprintf(STDCTR,"(sr_evalrf %d) SHORTCUT:", n_eval);
 #endif
 
- rgeo = sr_ckgeo((real *)par);
+ rgeo = sr_ckgeo(par);
 
 #ifdef CONTROL
 #ifdef SHORTCUT
@@ -177,7 +177,7 @@ FILE *io_stream, *log_stream;
 ***********************************************************************/
 
  n_calc ++;
- sr_mkinp((real *)par, n_calc, par_file);
+ sr_mkinp(par, n_calc, par_file);
 
 #ifdef SHORTCUT
 

--- a/src/search/srevalrf.c
+++ b/src/search/srevalrf.c
@@ -2,7 +2,7 @@
 GH/31.03.03
   file contains function:
 
-  real sr_evalrf(real *par)
+  real sr_evalrf(const real *par)
 
  Calculate IV curves and evaluate R factor
 
@@ -64,7 +64,7 @@ extern struct sratom_str *sr_atoms;
 extern struct search_str *sr_search;
 extern char *sr_project;
 
-real sr_evalrf(real *par)
+real sr_evalrf(const real *par)
 
 /***********************************************************************
 
@@ -132,7 +132,7 @@ FILE *io_stream, *log_stream;
  fprintf(STDCTR,"(sr_evalrf %d) SHORTCUT:", n_eval);
 #endif
 
- rgeo = sr_ckgeo( par );
+ rgeo = sr_ckgeo((real *)par);
 
 #ifdef CONTROL
 #ifdef SHORTCUT
@@ -177,7 +177,7 @@ FILE *io_stream, *log_stream;
 ***********************************************************************/
 
  n_calc ++;
- sr_mkinp(par, n_calc, par_file);
+ sr_mkinp((real *)par, n_calc, par_file);
 
 #ifdef SHORTCUT
 

--- a/src/search/srevalrf_mir.c
+++ b/src/search/srevalrf_mir.c
@@ -2,7 +2,7 @@
 GH/31.03.03
   file contains function:
 
-  real sr_evalrf(real *par)
+  real sr_evalrf(const real *par)
 
  Calculate IV curves and evaluate R factor
 
@@ -68,7 +68,7 @@ extern struct sratom_str *sr_atoms;
 extern struct search_str *sr_search;
 extern char *sr_project;
 
-real sr_evalrf(real *par)
+real sr_evalrf(const real *par)
 
 /***********************************************************************
 
@@ -131,7 +131,7 @@ char *new_path;
    fprintf(STDCTR, "(sr_evalrf %d) SHORTCUT:", n_eval);
  #endif
 
- rgeo = sr_ckgeo( par );
+ rgeo = sr_ckgeo((real *)par);
 
  #ifdef CONTROL
    #ifdef SHORTCUT
@@ -184,7 +184,7 @@ char *new_path;
 ***********************************************************************/
 
  n_calc ++;
- sr_mkinp_mir(par, n_calc, par_file);
+ sr_mkinp_mir((real *)par, n_calc, par_file);
 
 #ifdef SHORTCUT
 
@@ -379,7 +379,6 @@ char *new_path;
 
  return (rfac + rgeo);
 }
-
 
 
 

--- a/src/search/srevalrf_mir.c
+++ b/src/search/srevalrf_mir.c
@@ -131,7 +131,7 @@ char *new_path;
    fprintf(STDCTR, "(sr_evalrf %d) SHORTCUT:", n_eval);
  #endif
 
- rgeo = sr_ckgeo((real *)par);
+ rgeo = sr_ckgeo(par);
 
  #ifdef CONTROL
    #ifdef SHORTCUT
@@ -184,7 +184,7 @@ char *new_path;
 ***********************************************************************/
 
  n_calc ++;
- sr_mkinp_mir((real *)par, n_calc, par_file);
+ sr_mkinp_mir(par, n_calc, par_file);
 
 #ifdef SHORTCUT
 
@@ -379,7 +379,6 @@ char *new_path;
 
  return (rfac + rgeo);
 }
-
 
 
 

--- a/src/search/srevalrf_mir_gsl.c
+++ b/src/search/srevalrf_mir_gsl.c
@@ -32,6 +32,9 @@ LD/01.07.2014 - Update for compatibility with the GNU Scientific Library
 #include "search.h"
 #include "copy_file.h"
 
+real sr_ckgeo_gsl(const gsl_vector *par);
+int sr_mkinp_mir_gsl(gsl_vector *par, int i_call, char *filename);
+
 #define CONTROL
 #define ERROR
 
@@ -128,7 +131,7 @@ char *new_path;
    fprintf(STDCTR,"(sr_evalrf_gsl %d) SHORTCUT:", n_eval);
  #endif
 
- rgeo = sr_ckgeo( par );
+ rgeo = sr_ckgeo_gsl(par);
 
  #ifdef CONTROL
    #ifdef SHORTCUT
@@ -181,7 +184,7 @@ char *new_path;
 ***********************************************************************/
 
  n_calc ++;
- sr_mkinp_mir(par, n_calc, par_file);
+ sr_mkinp_mir_gsl(par, n_calc, par_file);
 
 #ifdef SHORTCUT
 
@@ -378,8 +381,6 @@ char *new_path;
 
  return (rfac + rgeo);
 }
-
-
 
 
 

--- a/src/search/srhelp.c
+++ b/src/search/srhelp.c
@@ -37,6 +37,10 @@ void search_usage(FILE *output) {
     fprintf(output, "  --pso-c1 <n>          : set PSO cognitive coefficient.\n");
     fprintf(output, "  --pso-c2 <n>          : set PSO social coefficient.\n");
     fprintf(output, "  --pso-vmax <n>        : set PSO velocity clamp.\n");
+    fprintf(output, "  --de-pop <n>          : set DE population size.\n");
+    fprintf(output, "  --de-weight <n>       : set DE weight factor.\n");
+    fprintf(output, "  --de-cr <n>           : set DE crossover rate.\n");
+    fprintf(output, "  --de-span <n>         : set DE initial span.\n");
     fprintf(output, "  -v <vertex_file>      : file to read vertex information if resuming search\n");                
     fprintf(output, "  -V --version          : print version and information about this program\n");
     fprintf(output, "\n");

--- a/src/search/srhelp.c
+++ b/src/search/srhelp.c
@@ -29,9 +29,9 @@ void search_usage(FILE *output) {
 	fprintf(output, "  -i <inp_file>         : surface parameter input file\n");
     fprintf(output, "  -s <search_type>      : can be \n");
     sr_optimizer_print_help(output);
-    fprintf(output, "  --max-evals <n>       : limit objective evaluations (simplex/PSO).\n");
-    fprintf(output, "  --max-iters <n>       : limit iterations (Powell/annealing/PSO).\n");
-    fprintf(output, "  --seed <n>            : seed stochastic optimizers (annealing/PSO, 0=default).\n");
+    fprintf(output, "  --max-evals <n>       : limit objective evaluations (simplex/PSO/DE).\n");
+    fprintf(output, "  --max-iters <n>       : limit iterations (Powell/annealing/PSO/DE).\n");
+    fprintf(output, "  --seed <n>            : seed stochastic optimizers (annealing/PSO/DE, 0=default).\n");
     fprintf(output, "  --pso-swarm <n>       : set PSO swarm size.\n");
     fprintf(output, "  --pso-inertia <n>     : set PSO inertia weight.\n");
     fprintf(output, "  --pso-c1 <n>          : set PSO cognitive coefficient.\n");

--- a/src/search/srmkinp.c
+++ b/src/search/srmkinp.c
@@ -33,7 +33,7 @@ extern struct search_str *sr_search;
 
 char line_buffer[STRSZ];
 
-int sr_mkinp(real *par, int i_call, char *filename)
+int sr_mkinp(const real *par, int i_call, char *filename)
 
 /***********************************************************************
  - Set up inputfile for IV program

--- a/src/search/srmkinp_mir.c
+++ b/src/search/srmkinp_mir.c
@@ -35,7 +35,7 @@ extern struct search_str *sr_search;
 
 char line_buffer[STRSZ];
 
-int sr_mkinp_mir(real *par, int i_call, char *filename)
+int sr_mkinp_mir(const real *par, int i_call, char *filename)
 
 /***********************************************************************
  - Set up inputfile for IV program

--- a/src/search/srpso.c
+++ b/src/search/srpso.c
@@ -288,7 +288,7 @@ void sr_pso(int ndim, real dpos, const char *bak_file, const char *log_file)
   real best_val = 0.0;
   int evals = 0;
 
-  if (sr_pso_optimize(&cfg, ndim, (real (*)(const real *))sr_evalrf, best, &best_val, &evals) != 0) {
+  if (sr_pso_optimize(&cfg, ndim, sr_evalrf, best, &best_val, &evals) != 0) {
     sr_free_vector(best);
     fprintf(STDERR, "*** error (sr_pso): optimisation failed\n");
     exit(1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,18 @@ else()
 endif()
 add_test(NAME search.pso COMMAND test_search_pso)
 
+add_executable(test_search_de
+    test_search_de.c
+    $<TARGET_OBJECTS:cleed_test_support>
+)
+target_include_directories(test_search_de PRIVATE ${CLEED_TEST_INCLUDE_DIRS})
+if (WIN32)
+    target_link_libraries(test_search_de PRIVATE searchStatic m)
+else()
+    target_link_libraries(test_search_de PRIVATE search m)
+endif()
+add_test(NAME search.de COMMAND test_search_de)
+
 add_executable(test_search_vertex_stats
     test_search_vertex_stats.c
     $<TARGET_OBJECTS:cleed_test_support>

--- a/tests/test_search_amebsa.c
+++ b/tests/test_search_amebsa.c
@@ -14,7 +14,7 @@
 
 extern uint64_t sa_idum;
 
-static real quadratic_2d(real *x)
+static real quadratic_2d(const real *x)
 {
     const real dx = x[1] - 1.0;
     const real dy = x[2] + 2.0;

--- a/tests/test_search_amoeba.c
+++ b/tests/test_search_amoeba.c
@@ -11,7 +11,7 @@
 
 #include "test_support.h"
 
-static real quadratic_2d(real *x)
+static real quadratic_2d(const real *x)
 {
     const real dx = x[1] - 1.0;
     const real dy = x[2] + 2.0;

--- a/tests/test_search_de.c
+++ b/tests/test_search_de.c
@@ -1,0 +1,51 @@
+#include "search.h"
+
+// cppcheck-suppress missingIncludeSystem
+#include <math.h>
+// cppcheck-suppress missingIncludeSystem
+#include <stdio.h>
+
+#include "test_support.h"
+
+static real quadratic_2d(real *x)
+{
+    const real dx = x[1] - (real)1.0;
+    const real dy = x[2] + (real)2.0;
+    return (dx * dx) + (dy * dy);
+}
+
+static int run_de_regression(void)
+{
+    const int ndim = 2;
+    sr_de_cfg cfg;
+    sr_de_cfg_init(&cfg, ndim, (real)1.0);
+    cfg.population = 24;
+    cfg.max_evals = 3000;
+    cfg.seed = 42;
+
+    real best[3] = {0};
+    real best_val = 0.0;
+    int evals = 0;
+
+    if (sr_de_optimize(&cfg, ndim, quadratic_2d, best, &best_val, &evals) != 0) {
+        fprintf(stderr, "sr_de_optimize failed\n");
+        return 1;
+    }
+
+    const real tol = (real)0.25;
+    if (fabs(best[1] - (real)1.0) > tol || fabs(best[2] + (real)2.0) > tol) {
+        fprintf(stderr, "unexpected optimum: (%g, %g)\n", (double)best[1], (double)best[2]);
+        return 1;
+    }
+    CLEED_TEST_ASSERT(best_val >= 0.0);
+    CLEED_TEST_ASSERT(evals > 0);
+    return 0;
+}
+
+int main(void)
+{
+    if (run_de_regression() != 0) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/test_search_de.c
+++ b/tests/test_search_de.c
@@ -9,8 +9,8 @@
 
 static real quadratic_2d(const real *x)
 {
-    const real dx = x[1] - (real)1.0;
-    const real dy = x[2] + (real)2.0;
+    const real dx = x[1] - 1.0;
+    const real dy = x[2] + 2.0;
     return (dx * dx) + (dy * dy);
 }
 
@@ -18,7 +18,7 @@ static int run_de_regression(void)
 {
     const int ndim = 2;
     sr_de_cfg cfg;
-    sr_de_cfg_init(&cfg, ndim, (real)1.0);
+    sr_de_cfg_init(&cfg, ndim, 1.0);
     cfg.population = 24;
     cfg.max_evals = 3000;
     cfg.seed = 42;
@@ -32,8 +32,8 @@ static int run_de_regression(void)
         return 1;
     }
 
-    const real tol = (real)0.25;
-    if (fabs(best[1] - (real)1.0) > tol || fabs(best[2] + (real)2.0) > tol) {
+    const real tol = 0.25;
+    if (fabs(best[1] - 1.0) > tol || fabs(best[2] + 2.0) > tol) {
         fprintf(stderr, "unexpected optimum: (%g, %g)\n", (double)best[1], (double)best[2]);
         return 1;
     }

--- a/tests/test_search_de.c
+++ b/tests/test_search_de.c
@@ -34,7 +34,7 @@ static int run_de_regression(void)
 
     const real tol = 0.25;
     if (fabs(best[1] - 1.0) > tol || fabs(best[2] + 2.0) > tol) {
-        fprintf(stderr, "unexpected optimum: (%g, %g)\n", (double)best[1], (double)best[2]);
+        fprintf(stderr, "unexpected optimum: (%g, %g)\n", best[1], best[2]);
         return 1;
     }
     CLEED_TEST_ASSERT(best_val >= 0.0);

--- a/tests/test_search_de.c
+++ b/tests/test_search_de.c
@@ -7,7 +7,7 @@
 
 #include "test_support.h"
 
-static real quadratic_2d(real *x)
+static real quadratic_2d(const real *x)
 {
     const real dx = x[1] - (real)1.0;
     const real dy = x[2] + (real)2.0;

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -156,6 +156,10 @@ static int test_config_from_env_pso(void)
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_PSO_C1", "1.50") == 0);
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_PSO_C2", "1.60") == 0);
     CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_PSO_VMAX", "2.00") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_DE_POP", "40") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_DE_WEIGHT", "0.65") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_DE_CR", "0.85") == 0);
+    CLEED_TEST_ASSERT(test_set_env_value("CSEARCH_DE_SPAN", "1.75") == 0);
 
     sr_optimizer_config_from_env(&cfg);
 
@@ -167,6 +171,10 @@ static int test_config_from_env_pso(void)
     CLEED_TEST_ASSERT(fabs(cfg.pso_c1 - (real)1.50) < (real)1e-6);
     CLEED_TEST_ASSERT(fabs(cfg.pso_c2 - (real)1.60) < (real)1e-6);
     CLEED_TEST_ASSERT(fabs(cfg.pso_vmax - (real)2.00) < (real)1e-6);
+    CLEED_TEST_ASSERT(cfg.de_population == 40);
+    CLEED_TEST_ASSERT(fabs(cfg.de_weight - (real)0.65) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.de_crossover - (real)0.85) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.de_init_span - (real)1.75) < (real)1e-6);
 
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
@@ -176,6 +184,10 @@ static int test_config_from_env_pso(void)
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_PSO_C1") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_PSO_C2") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_PSO_VMAX") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_DE_POP") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_DE_WEIGHT") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_DE_CR") == 0);
+    CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_DE_SPAN") == 0);
 
     return 0;
 }

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -175,14 +175,14 @@ static int test_config_from_env_pso(void)
     CLEED_TEST_ASSERT(cfg.max_iters == 456);
     CLEED_TEST_ASSERT(cfg.seed == 789);
     CLEED_TEST_ASSERT(cfg.pso_swarm_size == 32);
-    CLEED_TEST_ASSERT(fabs(cfg.pso_inertia - (real)0.73) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(cfg.pso_c1 - (real)1.50) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(cfg.pso_c2 - (real)1.60) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(cfg.pso_vmax - (real)2.00) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.pso_inertia - 0.73) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.pso_c1 - 1.50) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.pso_c2 - 1.60) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.pso_vmax - 2.00) < 1e-6);
     CLEED_TEST_ASSERT(cfg.de_population == 40);
-    CLEED_TEST_ASSERT(fabs(cfg.de_weight - (real)0.65) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(cfg.de_crossover - (real)0.85) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(cfg.de_init_span - (real)1.75) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.de_weight - 0.65) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.de_crossover - 0.85) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(cfg.de_init_span - 1.75) < 1e-6);
 
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_EVALS") == 0);
     CLEED_TEST_ASSERT(test_unset_env_value("CSEARCH_MAX_ITERS") == 0);
@@ -270,15 +270,15 @@ static int test_config_apply(void)
     cfg.max_iters = 123;
     cfg.max_evals = 456;
     cfg.de_population = 40;
-    cfg.de_weight = (real)0.65;
-    cfg.de_crossover = (real)0.85;
-    cfg.de_init_span = (real)1.75;
+    cfg.de_weight = 0.65;
+    cfg.de_crossover = 0.85;
+    cfg.de_init_span = 1.75;
     sr_optimizer_config_apply(&cfg);
 
     CLEED_TEST_ASSERT(sr_de_population == 40);
-    CLEED_TEST_ASSERT(fabs(sr_de_weight - (real)0.65) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(sr_de_crossover - (real)0.85) < (real)1e-6);
-    CLEED_TEST_ASSERT(fabs(sr_de_init_span - (real)1.75) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(sr_de_weight - 0.65) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(sr_de_crossover - 0.85) < 1e-6);
+    CLEED_TEST_ASSERT(fabs(sr_de_init_span - 1.75) < 1e-6);
     CLEED_TEST_ASSERT(sr_de_iter_limit == 123);
     CLEED_TEST_ASSERT(sr_de_eval_limit == 456);
 

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -102,6 +102,10 @@ static int test_lookup_by_name(void)
     CLEED_TEST_ASSERT(opt != NULL);
     CLEED_TEST_ASSERT(opt->type == SR_PSO);
 
+    opt = sr_optimizer_by_name("de");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_DIFFERENTIAL_EVOLUTION);
+
     opt = sr_optimizer_by_name("unknown");
     CLEED_TEST_ASSERT(opt == NULL);
 

--- a/tests/test_search_optimizer.c
+++ b/tests/test_search_optimizer.c
@@ -106,6 +106,14 @@ static int test_lookup_by_name(void)
     CLEED_TEST_ASSERT(opt != NULL);
     CLEED_TEST_ASSERT(opt->type == SR_DIFFERENTIAL_EVOLUTION);
 
+    opt = sr_optimizer_by_name("differential");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_DIFFERENTIAL_EVOLUTION);
+
+    opt = sr_optimizer_by_name("differential-evolution");
+    CLEED_TEST_ASSERT(opt != NULL);
+    CLEED_TEST_ASSERT(opt->type == SR_DIFFERENTIAL_EVOLUTION);
+
     opt = sr_optimizer_by_name("unknown");
     CLEED_TEST_ASSERT(opt == NULL);
 
@@ -254,6 +262,25 @@ static int test_config_apply(void)
     sr_optimizer_config_apply(&cfg);
 
     CLEED_TEST_ASSERT(sa_idum == cfg.seed);
+
+    /* verify that sr_optimizer_config_apply propagates DE config into globals */
+    test_restore_globals(1, 2, 3, UINT64_C(55));
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.max_iters = 123;
+    cfg.max_evals = 456;
+    cfg.de_population = 40;
+    cfg.de_weight = (real)0.65;
+    cfg.de_crossover = (real)0.85;
+    cfg.de_init_span = (real)1.75;
+    sr_optimizer_config_apply(&cfg);
+
+    CLEED_TEST_ASSERT(sr_de_population == 40);
+    CLEED_TEST_ASSERT(fabs(sr_de_weight - (real)0.65) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(sr_de_crossover - (real)0.85) < (real)1e-6);
+    CLEED_TEST_ASSERT(fabs(sr_de_init_span - (real)1.75) < (real)1e-6);
+    CLEED_TEST_ASSERT(sr_de_iter_limit == 123);
+    CLEED_TEST_ASSERT(sr_de_eval_limit == 456);
 
     test_restore_globals(orig_amoeba, orig_powell, orig_sa, orig_seed);
 

--- a/tests/test_search_powell.c
+++ b/tests/test_search_powell.c
@@ -9,7 +9,7 @@
 
 #include "test_support.h"
 
-static real quadratic_2d(real *x)
+static real quadratic_2d(const real *x)
 {
     const real dx = x[1] - 1.0;
     const real dy = x[2] + 2.0;
@@ -64,4 +64,3 @@ int main(void)
 {
     return run_powell_regression();
 }
-

--- a/tests/test_search_simplex.c
+++ b/tests/test_search_simplex.c
@@ -4,7 +4,7 @@
 
 static int g_ndim = 0;
 
-static real test_obj(real *x)
+static real test_obj(const real *x)
 {
   real sum = 0.0;
   for (int j = 1; j <= g_ndim; j++) {
@@ -80,4 +80,3 @@ int main(void)
   if (test_extremes_and_centroid() != 0) return 1;
   return 0;
 }
-


### PR DESCRIPTION
## Summary

Adds a Differential Evolution (DE) optimizer to `csearch`, completing the modern optimizer suite with a robust population-based global optimization method.

## Problem

| Issue | Impact |
|-------|--------|
| Missing evolutionary optimization | No DE despite being highly effective for global optimization |
| Optimizer suite incomplete | Modernization roadmap calls for PSO + DE |

## Solution

### DE Algorithm (DE/rand/1/bin)

```
┌─────────────────────────────────────────────────────────────┐
│                    DE Core Loop                              │
├─────────────────────────────────────────────────────────────┤
│  1. Initialize population with random positions             │
│  2. For each target vector x:                               │
│     a. Select 3 distinct random vectors (a, b, c)           │
│     b. Create mutant: v = a + F*(b - c)                     │
│     c. Create trial via binomial crossover with CR          │
│     d. Evaluate trial; replace target if better             │
│  3. Update global best                                      │
│  4. Repeat until convergence or budget exhausted            │
└─────────────────────────────────────────────────────────────┘
```

### New CLI Options

| Option | Environment Variable | Default | Description |
|--------|---------------------|---------|-------------|
| `--search de` | - | - | Select DE optimizer |
| `--de-pop N` | `CSEARCH_DE_POP` | 10*ndim | Population size |
| `--de-weight F` | `CSEARCH_DE_WEIGHT` | 0.8 | Mutation weight (F) |
| `--de-cr CR` | `CSEARCH_DE_CR` | 0.9 | Crossover probability |
| `--de-span S` | `CSEARCH_DE_SPAN` | 1.0 | Initial span multiplier |

### Complete Optimizer Registry

| Type | Primary | Aliases | Status |
|------|---------|---------|--------|
| Simplex | `si` | `sx`, `simplex` | Implemented (default) |
| Powell | `po` | `powell` | Implemented |
| Simulated Annealing | `sa` | `anneal` | Implemented |
| PSO | `ps` | `pso`, `swarm` | Implemented |
| **DE** | **`de`** | **`differential-evolution`** | **Implemented (new)** |
| Genetic Algorithm | `ga` | `genetic` | Stub only |

### Key Files

| File | Purpose |
|------|---------|
| [`srde.c`](https://github.com/Liam-Deacon/CLEED/blob/423d0bf/src/search/srde.c) | DE core algorithm and driver |
| [`search_func.h`](https://github.com/Liam-Deacon/CLEED/blob/423d0bf/src/include/search_func.h) | DE config struct and API |
| [`sr_optimizers.c`](https://github.com/Liam-Deacon/CLEED/blob/423d0bf/src/search/sr_optimizers.c) | Registry entry for DE |
| [`test_search_de.c`](https://github.com/Liam-Deacon/CLEED/blob/423d0bf/tests/test_search_de.c) | DE regression tests |

## Testing

```bash
# Build and test
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel
ctest --test-dir build --output-on-failure -R 'search.de|search.optimizer'

# Pre-commit
python3 -m pre_commit run --all-files
```

All 19 tests pass (17 existing + PSO + DE).

## Dependencies

```
master
  └── PR #65 (optimizer interface)
        └── PR #66 (PSO)
              └── PR #67 (DE) ← this PR
```

## Follow-ups

- [ ] Benchmark DE against simplex/SA/PSO defaults
- [ ] Consider hybrid approaches (e.g., DE-SA)

## Summary by Sourcery

Introduce a differential evolution (DE) optimizer as a first-class search method alongside existing optimizers, with full CLI, configuration, and registry integration.

New Features:
- Add a differential evolution (DE) optimizer implementation and driver, including configuration struct and optimization routine.
- Expose DE as a selectable optimizer type in the registry with primary name 'de' and aliases, and wire it into the global search entry points.
- Add CLI flags and environment variables to configure DE-specific parameters such as population size, mutation weight, crossover rate, and initial span.

Enhancements:
- Extend global optimizer configuration and logging to handle DE limits and hyperparameters consistently with other optimizers.
- Update user-facing help and man pages to document DE as a supported optimizer and describe its tuning options.

Tests:
- Add a DE regression test that optimizes a simple quadratic to validate behavior and determinism, and integrate it into the CTest suite.
- Extend optimizer configuration tests to cover DE environment variable handling and lookup by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Differential Evolution (DE) optimizer selectable as "de".

* **Command-line & Environment**
  * New options --de-pop, --de-weight, --de-cr, --de-span and matching CSEARCH_DE_* env vars; eval/iter/seed options and mining choices now mention DE.

* **Documentation**
  * Help, man pages, examples and environment docs updated to document DE, defaults, and integration.

* **Tests**
  * Added tests and a test target validating DE behavior and config parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->