### PR TITLE
feat(core): add cleed core library target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ ENDIF()
 ADD_SUBDIRECTORY(rfac)
 ADD_SUBDIRECTORY(search)
 ADD_SUBDIRECTORY(cleed_core)
+ADD_SUBDIRECTORY(cleed_io)
 ADD_SUBDIRECTORY(scripts)
 
 # optional gui elements

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ IF (BUILD_PATT)
 ENDIF()
 ADD_SUBDIRECTORY(rfac)
 ADD_SUBDIRECTORY(search)
+ADD_SUBDIRECTORY(cleed_core)
 ADD_SUBDIRECTORY(scripts)
 
 # optional gui elements

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 ### automake file for csearch ###
 # Process this file with automake to produce Makefile.in
 
-SUBDIRS = aoi_leed aoi_rfac debye ftsmooth latt leed_nsym leed_sym mkiv patt rfac search scripts
+SUBDIRS = aoi_leed aoi_rfac debye ftsmooth latt leed_nsym leed_sym mkiv patt rfac search cleed_core scripts
 include_HEADERS = include

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 ### automake file for csearch ###
 # Process this file with automake to produce Makefile.in
 
-SUBDIRS = aoi_leed aoi_rfac debye ftsmooth latt leed_nsym leed_sym mkiv patt rfac search cleed_core scripts
+SUBDIRS = aoi_leed aoi_rfac debye ftsmooth latt leed_nsym leed_sym mkiv patt rfac search cleed_core cleed_io scripts
 include_HEADERS = include

--- a/src/cleed_core/CMakeLists.txt
+++ b/src/cleed_core/CMakeLists.txt
@@ -1,0 +1,34 @@
+# CLEED core library target
+
+set(cleed_core_SRCS
+    cleed_core.c
+)
+
+add_library(cleedCore SHARED ${cleed_core_SRCS})
+add_library(cleedCoreStatic STATIC ${cleed_core_SRCS})
+
+if (NOT WIN32)
+    set_target_properties(cleedCoreStatic PROPERTIES OUTPUT_NAME cleedCore)
+endif()
+
+target_include_directories(cleedCore PUBLIC ${PROJECT_SOURCE_DIR}/src/include)
+target_include_directories(cleedCoreStatic PUBLIC ${PROJECT_SOURCE_DIR}/src/include)
+
+# Link to core computation libraries.
+target_link_libraries(cleedCore PUBLIC search rfac)
+target_link_libraries(cleedCoreStatic PUBLIC searchStatic rfacStatic)
+
+if (WIN32)
+    install(TARGETS cleedCore
+        COMPONENT runtime
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION bin
+    )
+else()
+    install(TARGETS cleedCore
+        COMPONENT runtime
+        LIBRARY DESTINATION lib
+    )
+endif()
+
+install(TARGETS cleedCoreStatic ARCHIVE DESTINATION lib COMPONENT libraries)

--- a/src/cleed_core/CMakeLists.txt
+++ b/src/cleed_core/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(cleed_core_SRCS
     cleed_core.c
+    cleed_curve.c
 )
 
 add_library(cleedCore SHARED ${cleed_core_SRCS})

--- a/src/cleed_core/Makefile.am
+++ b/src/cleed_core/Makefile.am
@@ -9,6 +9,7 @@ else
 lib_LTLIBRARIES = libcleedcore.la
 endif
 
-libcleedcore_la_SOURCES = cleed_core.c
+libcleedcore_la_SOURCES = cleed_core.c \
+    cleed_curve.c
 
 libcleedcore_a_SOURCES = $(libcleedcore_la_SOURCES)

--- a/src/cleed_core/Makefile.am
+++ b/src/cleed_core/Makefile.am
@@ -1,0 +1,14 @@
+### automake file for cleed_core ###
+# Process this file with automake to produce Makefile.in
+
+lib_LIBRARIES = libcleedcore.a
+
+if WIN32
+bin_LTLIBRARIES = libcleedcore.la
+else
+lib_LTLIBRARIES = libcleedcore.la
+endif
+
+libcleedcore_la_SOURCES = cleed_core.c
+
+libcleedcore_a_SOURCES = $(libcleedcore_la_SOURCES)

--- a/src/cleed_core/cleed_core.c
+++ b/src/cleed_core/cleed_core.c
@@ -1,0 +1,13 @@
+/*********************************************************************
+ *                       CLEED_CORE.C
+ *
+ *  Core library entry points for CLEED.
+ *********************************************************************/
+
+#include "cleed_core.h"
+#include "search_ver.h"
+
+const char *cleed_core_version(void)
+{
+  return SEARCH_VERSION;
+}

--- a/src/cleed_core/cleed_curve.c
+++ b/src/cleed_core/cleed_curve.c
@@ -1,0 +1,110 @@
+/*********************************************************************
+ *                       CLEED_CURVE.C
+ *
+ *  In-memory curve helpers for CLEED.
+ *********************************************************************/
+
+// cppcheck-suppress missingIncludeSystem
+#include <math.h>
+// cppcheck-suppress missingIncludeSystem
+#include <stdlib.h>
+// cppcheck-suppress missingIncludeSystem
+#include <string.h>
+
+#include "cleed_core.h"
+
+int cleed_curve_alloc(cleed_curve *curve, size_t n)
+{
+  if (!curve || n == 0) {
+    return -1;
+  }
+
+  curve->E = (double *)calloc(n, sizeof(double));
+  curve->I = (double *)calloc(n, sizeof(double));
+  if (!curve->E || !curve->I) {
+    free(curve->E);
+    free(curve->I);
+    curve->E = NULL;
+    curve->I = NULL;
+    curve->n = 0;
+    return -1;
+  }
+
+  curve->n = n;
+  return 0;
+}
+
+void cleed_curve_free(cleed_curve *curve)
+{
+  if (!curve) return;
+  free(curve->E);
+  free(curve->I);
+  curve->E = NULL;
+  curve->I = NULL;
+  curve->n = 0;
+}
+
+int cleed_curve_copy(cleed_curve *dst, const cleed_curve *src)
+{
+  if (!dst || !src || src->n == 0 || !src->E || !src->I) {
+    return -1;
+  }
+  if (dst == src) {
+    return 0;
+  }
+
+  cleed_curve_free(dst);
+  if (cleed_curve_alloc(dst, src->n) != 0) {
+    return -1;
+  }
+
+  (void)memcpy(dst->E, src->E, src->n * sizeof(double));
+  (void)memcpy(dst->I, src->I, src->n * sizeof(double));
+  return 0;
+}
+
+static size_t cleed_curve_upper_index(const cleed_curve *curve, double energy)
+{
+  size_t lo = 0;
+  size_t hi = curve->n - 1;
+
+  while (hi - lo > 1) {
+    size_t mid = lo + (hi - lo) / 2;
+    if (energy <= curve->E[mid]) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+
+  return hi;
+}
+
+double cleed_curve_interp(const cleed_curve *curve, double energy)
+{
+  if (!curve || curve->n == 0 || !curve->E || !curve->I) {
+    return NAN;
+  }
+
+  if (curve->n == 1) {
+    return curve->I[0];
+  }
+
+  if (energy <= curve->E[0]) {
+    return curve->I[0];
+  }
+  if (energy >= curve->E[curve->n - 1]) {
+    return curve->I[curve->n - 1];
+  }
+
+  size_t hi = cleed_curve_upper_index(curve, energy);
+  size_t lo = hi - 1;
+  double e0 = curve->E[lo];
+  double e1 = curve->E[hi];
+  if (e1 <= e0) {
+    return curve->I[lo];
+  }
+
+  double t = (energy - e0) / (e1 - e0);
+  return curve->I[lo] + t * (curve->I[hi] - curve->I[lo]);
+}

--- a/src/cleed_io/CMakeLists.txt
+++ b/src/cleed_io/CMakeLists.txt
@@ -1,0 +1,33 @@
+# CLEED IO library target (stub)
+
+set(cleed_io_SRCS
+    cleed_io.c
+)
+
+add_library(cleedIO SHARED ${cleed_io_SRCS})
+add_library(cleedIOStatic STATIC ${cleed_io_SRCS})
+
+if (NOT WIN32)
+    set_target_properties(cleedIOStatic PROPERTIES OUTPUT_NAME cleedIO)
+endif()
+
+target_include_directories(cleedIO PUBLIC ${PROJECT_SOURCE_DIR}/src/include)
+target_include_directories(cleedIOStatic PUBLIC ${PROJECT_SOURCE_DIR}/src/include)
+
+target_link_libraries(cleedIO PUBLIC cleedCore)
+target_link_libraries(cleedIOStatic PUBLIC cleedCoreStatic)
+
+if (WIN32)
+    install(TARGETS cleedIO
+        COMPONENT runtime
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION bin
+    )
+else()
+    install(TARGETS cleedIO
+        COMPONENT runtime
+        LIBRARY DESTINATION lib
+    )
+endif()
+
+install(TARGETS cleedIOStatic ARCHIVE DESTINATION lib COMPONENT libraries)

--- a/src/cleed_io/Makefile.am
+++ b/src/cleed_io/Makefile.am
@@ -1,0 +1,14 @@
+### automake file for cleed_io ###
+# Process this file with automake to produce Makefile.in
+
+lib_LIBRARIES = libcleedio.a
+
+if WIN32
+bin_LTLIBRARIES = libcleedio.la
+else
+lib_LTLIBRARIES = libcleedio.la
+endif
+
+libcleedio_la_SOURCES = cleed_io.c
+
+libcleedio_a_SOURCES = $(libcleedio_la_SOURCES)

--- a/src/cleed_io/cleed_io.c
+++ b/src/cleed_io/cleed_io.c
@@ -1,0 +1,26 @@
+/*********************************************************************
+ *                       CLEED_IO.C
+ *
+ *  Stub I/O layer for CLEED curve data.
+ *********************************************************************/
+
+// cppcheck-suppress missingIncludeSystem
+#include <errno.h>
+
+#include "cleed_io.h"
+
+int cleed_io_read_curve(const char *path, cleed_curve *out_curve)
+{
+  (void)path;
+  (void)out_curve;
+  errno = ENOSYS;
+  return -1;
+}
+
+int cleed_io_write_curve(const char *path, const cleed_curve *curve)
+{
+  (void)path;
+  (void)curve;
+  errno = ENOSYS;
+  return -1;
+}

--- a/src/include/cleed_core.h
+++ b/src/include/cleed_core.h
@@ -1,0 +1,34 @@
+/*********************************************************************
+ *                       CLEED_CORE.H
+ *
+ *  Core library entry points for CLEED.
+ *********************************************************************/
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
+
+#ifndef CLEED_CORE_H
+#define CLEED_CORE_H
+
+#include <stddef.h>
+
+/**
+ * @brief In-memory LEED curve representation.
+ */
+typedef struct cleed_curve {
+  size_t n;
+  double *E;
+  double *I;
+} cleed_curve;
+
+/**
+ * @brief Return the core library version string.
+ */
+const char *cleed_core_version(void);
+
+#endif /* CLEED_CORE_H */
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+}
+#endif

--- a/src/include/cleed_core.h
+++ b/src/include/cleed_core.h
@@ -23,6 +23,40 @@ typedef struct cleed_curve {
 } cleed_curve;
 
 /**
+ * @brief Allocate a curve with space for n samples.
+ *
+ * @param curve Output curve struct.
+ * @param n Number of samples.
+ * @return 0 on success, non-zero on failure.
+ */
+int cleed_curve_alloc(cleed_curve *curve, size_t n);
+
+/**
+ * @brief Free curve storage and reset fields to zero.
+ */
+void cleed_curve_free(cleed_curve *curve);
+
+/**
+ * @brief Copy a curve into a destination curve (allocates storage).
+ *
+ * @param dst Destination curve.
+ * @param src Source curve.
+ * @return 0 on success, non-zero on failure.
+ */
+int cleed_curve_copy(cleed_curve *dst, const cleed_curve *src);
+
+/**
+ * @brief Linearly interpolate intensity at the given energy.
+ *
+ * If the energy is out of bounds, the nearest endpoint is returned.
+ *
+ * @param curve Input curve.
+ * @param energy Energy to sample.
+ * @return Interpolated intensity, or NaN if curve is invalid.
+ */
+double cleed_curve_interp(const cleed_curve *curve, double energy);
+
+/**
  * @brief Return the core library version string.
  */
 const char *cleed_core_version(void);

--- a/src/include/cleed_core.h
+++ b/src/include/cleed_core.h
@@ -4,14 +4,14 @@
  *  Core library entry points for CLEED.
  *********************************************************************/
 
-#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
-extern "C" {
-#endif
-
 #ifndef CLEED_CORE_H
 #define CLEED_CORE_H
 
 #include <stddef.h>
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
 
 /**
  * @brief In-memory LEED curve representation.
@@ -61,8 +61,8 @@ double cleed_curve_interp(const cleed_curve *curve, double energy);
  */
 const char *cleed_core_version(void);
 
-#endif /* CLEED_CORE_H */
-
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
 }
 #endif
+
+#endif /* CLEED_CORE_H */

--- a/src/include/cleed_io.h
+++ b/src/include/cleed_io.h
@@ -1,0 +1,34 @@
+/*********************************************************************
+ *                       CLEED_IO.H
+ *
+ *  I/O helpers for CLEED curves (stub layer).
+ *********************************************************************/
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
+
+#ifndef CLEED_IO_H
+#define CLEED_IO_H
+
+#include "cleed_core.h"
+
+/**
+ * @brief Read a curve from disk.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int cleed_io_read_curve(const char *path, cleed_curve *out_curve);
+
+/**
+ * @brief Write a curve to disk.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int cleed_io_write_curve(const char *path, const cleed_curve *curve);
+
+#endif /* CLEED_IO_H */
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+}
+#endif

--- a/src/include/cleed_io.h
+++ b/src/include/cleed_io.h
@@ -4,14 +4,14 @@
  *  I/O helpers for CLEED curves (stub layer).
  *********************************************************************/
 
-#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
-extern "C" {
-#endif
-
 #ifndef CLEED_IO_H
 #define CLEED_IO_H
 
 #include "cleed_core.h"
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
 
 /**
  * @brief Read a curve from disk.
@@ -27,8 +27,8 @@ int cleed_io_read_curve(const char *path, cleed_curve *out_curve);
  */
 int cleed_io_write_curve(const char *path, const cleed_curve *curve);
 
-#endif /* CLEED_IO_H */
-
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
 }
 #endif
+
+#endif /* CLEED_IO_H */


### PR DESCRIPTION
## Problem
- Establish a library-first entry point to start decoupling core logic from CLI tools for WASM readiness.

## Solution
- Add in-memory curve helpers (alloc/free/copy/interp) to cleed_core.
- Introduce a stub cleed_io library layer for future file parsing.
- Wire new subdirectories into CMake + autotools build graphs.

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target cleedCore cleedIO`
- `python3 -m pre_commit run --all-files`

## Links
- https://github.com/Liam-Deacon/CLEED/blob/91c9dfd11b1e88c34c3a46d601a417d6cf74b56a/src/cleed_core/cleed_curve.c
- https://github.com/Liam-Deacon/CLEED/blob/91c9dfd11b1e88c34c3a46d601a417d6cf74b56a/src/cleed_io/cleed_io.c
- https://github.com/Liam-Deacon/CLEED/blob/91c9dfd11b1e88c34c3a46d601a417d6cf74b56a/src/include/cleed_core.h

## Follow-ups
- [ ] Flesh out cleed_io readers/writers for legacy formats.
